### PR TITLE
Add basic port validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ int main() {
         res->end(const char *, size_t);
     });
 
-    h.listen(3000);
+    // connect to port and exit if blocked
+    if (!h.listen(3000)) return 1;
     h.run();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ int main() {
         res->end(const char *, size_t);
     });
 
-    // connect to port and exit if blocked
-    if (!h.listen(3000)) return 1;
-    h.run();
+    if (h.listen(3000)) {
+        h.run();
+    }
 }
 ```
 Get the sources of the uws.chat server [here](https://github.com/uWebSockets/website/blob/master/main.cpp). Learn from the tests [here](tests/main.cpp).

--- a/examples/echo.cpp
+++ b/examples/echo.cpp
@@ -8,6 +8,7 @@ int main()
         ws->send(message, length, opCode);
     });
 
-    h.listen(3000);
+    // connect to port and exit if blocked
+    if (!h.listen(3000)) return 1;
     h.run();
 }

--- a/examples/echo.cpp
+++ b/examples/echo.cpp
@@ -8,7 +8,7 @@ int main()
         ws->send(message, length, opCode);
     });
 
-    // connect to port and exit if blocked
-    if (!h.listen(3000)) return 1;
-    h.run();
+    if (h.listen(3000)) {
+        h.run();
+    }
 }


### PR DESCRIPTION
In order to keep the examples minimal, just return an exit error code.