### PR TITLE
HAVE_REUSEPORT: Other TCP/IP stacks may have SO_REUSEPORT too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CPP_OSX := -stdlib=libc++ -mmacosx-version-min=10.7 -undefined dynamic_lookup $(
 default:
 	make `(uname -s)`
 Linux:
-	$(CXX) $(CPPFLAGS) $(CFLAGS) $(CPP_SHARED) -s -o libuWS.so
+	$(CXX) $(CPPFLAGS) $(CFLAGS) -DHAVE_REUSEPORT $(CPP_SHARED) -s -o libuWS.so
 Darwin:
 	$(CXX) $(CPPFLAGS) $(CFLAGS) $(CPP_SHARED) $(CPP_OSX) -o libuWS.dylib
 .PHONY: install

--- a/src/Node.h
+++ b/src/Node.h
@@ -160,7 +160,7 @@ public:
             return true;
         }
 
-#ifdef __linux
+#ifdef HAVE_REUSEPORT
 #ifdef SO_REUSEPORT
         if (options & REUSE_PORT) {
             int optval = 1;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1181,8 +1181,8 @@ int main(int argc, char *argv[])
     testConnections();
     testTransfers();
 
-    // Linux-only feature
-#ifdef __linux__
+    // UNIX TCP/IP stacks
+#if defined(__linux) || defined(__FreeBSD__)
     testReusePort();
 #endif
 


### PR DESCRIPTION
Do not use __linux for this feature.