### PR TITLE
Test local libuWS library if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ clean:
 	rm -f libuWS.dylib
 .PHONY: tests
 tests:
-	$(CXX) $(CPP_OPENSSL_OSX) -std=c++11 -O3 tests/main.cpp -Isrc -o testsBin -lpthread -luWS -lssl -lcrypto -lz -luv
+	$(CXX) $(CPP_OPENSSL_OSX) -std=c++11 -O3 tests/main.cpp -Isrc -o testsBin -lpthread -L. -luWS -lssl -lcrypto -lz -luv


### PR DESCRIPTION
If we don't install the library globally, we get the following error
from the linker on Linux:

    $ make tests
    g++ -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include -I/usr/local/include -std=c++11 -O3 -g tests/main.cpp -Isrc -o testsBin -lpthread -luWS -lssl -lcrypto -lz -L/usr/local/lib -luv
    /usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -luWS
collect2: error: ld returned 1 exit status