### PR TITLE
Avoid re-defining SOCKET_ERROR and INVALID_SOCKET if they're already defined

### DIFF
--- a/src/Networking.h
+++ b/src/Networking.h
@@ -61,8 +61,23 @@ inline SOCKET dup(SOCKET socket) {
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <cstring>
-#define SOCKET_ERROR -1
-#define INVALID_SOCKET -1
+
+#ifndef SOCKET_ERROR
+#define SOCKET_ERROR (-1)
+#else
+#if SOCKET_ERROR != -1
+#error SOCKET_ERROR is defined and its value is not -1
+#endif
+#endif
+
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET (-1)
+#else
+#if INVALID_SOCKET != -1
+#error INVALID_SOCKET is defined and its value is not -1
+#endif
+#endif
+
 #define WIN32_EXPORT
 #endif
 


### PR DESCRIPTION
Macros `SOCKET_ERROR` and `INVALID_SOCKET` are commonly defined by other packages (e.g. look at WebRTC's source: [webrtc/rtc_base/socket.h](https://chromium.googlesource.com/external/webrtc/+/master/webrtc/rtc_base/socket.h#116)). Avoid redefining if it exists. If it exists and the value is not what we expect, throw a compile-time error.