### PR TITLE
Add onTransfer for clients on Hub class

### DIFF
--- a/src/Hub.h
+++ b/src/Hub.h
@@ -71,6 +71,7 @@ public:
     using Group<SERVER>::onConnection;
     using Group<CLIENT>::onConnection;
     using Group<SERVER>::onTransfer;
+	using Group<CLIENT>::onTransfer;
     using Group<SERVER>::onMessage;
     using Group<CLIENT>::onMessage;
     using Group<SERVER>::onDisconnection;

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -71,7 +71,7 @@ public:
     using Group<SERVER>::onConnection;
     using Group<CLIENT>::onConnection;
     using Group<SERVER>::onTransfer;
-	using Group<CLIENT>::onTransfer;
+    using Group<CLIENT>::onTransfer;
     using Group<SERVER>::onMessage;
     using Group<CLIENT>::onMessage;
     using Group<SERVER>::onDisconnection;


### PR DESCRIPTION
Easy way to make a onTransfer from hub.

If not you need to make something like this:
```
        m_Hub->getDefaultGroup<uWS::CLIENT>().onTransfer([this]( uWS::WebSocket<uWS::CLIENT> *ws ) {
            std::cout << "WebSocket: Client Transfer" << std::endl;
            m_ws = ws;
        });
```

instance of:
```
	m_Hub->onTransfer([this](uWS::WebSocket<uWS::CLIENT> *ws) {
            std::cout << "WebSocket: Client Transfer" << std::endl;
            m_ws = ws;
        });
```
