### PR TITLE
Use '> /dev/null 2>&1' redirection

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -828,44 +828,44 @@ void testHTTP() {
         FILE *nc;
 
         // invalid data
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("invalid http", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("\r\n\r\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("\r\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("\r\n\r", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("\r", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET \r\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET / HTTP/1.1\r\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET / HTTP/1.1\r\nHost: localhost:3000", nc);
         pclose(nc);
 
         // segmented GET
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET /segme", nc);
         fflush(nc);
         usleep(100000);
@@ -884,7 +884,7 @@ void testHTTP() {
         pclose(nc);
 
         // segmented upgrade
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET /upgra", nc);
         fflush(nc);
         usleep(100000);
@@ -907,14 +907,14 @@ void testHTTP() {
         pclose(nc);
 
         // slow GET should get disconnected
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         sleep(3);
         fputs("GET /slowRequest HTTP/1.1\r\n\r\n", nc);
         pclose(nc);
 
         // post tests with increading data length
         for (int j = 0; j < 10; j++) {
-            nc = popen("nc localhost 3000 &> /dev/null", "w");
+            nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
             fputs("POST /postTest HTTP/1.1\r\nContent-Length: ", nc);
 
             int contentLength = j * 1000000;
@@ -931,24 +931,24 @@ void testHTTP() {
         // todo: two-in-one GET, two-in-one GET, upgrade, etc
 
         // segmented second GET
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET /packedTest HTTP/1.1\r\n\r\nGET /packedTest HTTP/", nc);
         fflush(nc);
         usleep(100000);
         fputs("1.1\r\n\r\n", nc);
         pclose(nc);
 
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET /packedTest HTTP/1.1\r\n\r\nGET /packedTest HTTP/1.1\r\n\r\n", nc);
         pclose(nc);
 
         // out of order responses
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("GET /firstRequest HTTP/1.1\r\n\r\nGET /secondRequest HTTP/1.1\r\n\r\n", nc);
         pclose(nc);
 
         // shutdown
-        nc = popen("nc localhost 3000 &> /dev/null", "w");
+        nc = popen("nc localhost 3000 > /dev/null 2>&1", "w");
         fputs("PUT /closeServer HTTP/1.1\r\n\r\n", nc);
         pclose(nc);
         if (expectedRequests != 18) {


### PR DESCRIPTION
Hi,

For Debian/Ubuntu, ``dash`` is used as ``/bin/sh`` (https://wiki.ubuntu.com/DashAsBinSh) and `dash` does not support ``&>`` style redirection(https://wiki.ubuntu.com/DashAsBinSh#A.26.3E). I tried to change the ``SHELL`` environmental variable to use ``/bin/bash``, but ``popen`` does not seem to use that variable.
This PR changes the redirection style.

I tested by the following Dockerfile

```
FROM ubuntu:16.04
#FROM debian:jessie
RUN apt-get update && \
    apt-get install -y build-essential libssl-dev netcat-openbsd
ADD . /uWebSockets
RUN cd uWebSockets && make && make install && g++ -std=c++11 -O3 tests/main.cpp -Isrc -o testsBin -lpthread -L. -luWS -lssl -lcrypto -lz
ENV SHELL /bin/bash
CMD cd uWebSockets && ./testsBin
```

```bash
$ docker build -t test .
$ docker run --rm --net=host test
```

Unfortunately ``debian:jessie`` failed with segmentation fault. It might be related to #746 .

Thanks.