### PR TITLE
Allow for installation to custom prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,17 @@ install:
 	make install`(uname -s)`
 .PHONY: installLinux
 installLinux:
-	if [ -d "/usr/lib64" ]; then cp libuWS.so /usr/lib64/; else cp libuWS.so /usr/lib/; fi
-	mkdir -p /usr/include/uWS
-	cp src/*.h /usr/include/uWS/
+	$(eval PREFIX ?= /usr)
+	if [ -d "/usr/lib64" ]; then mkdir -p $(PREFIX)/lib64 && cp libuWS.so $(PREFIX)/lib64/; else mkdir -p $(PREFIX)/lib && cp libuWS.so $(PREFIX)/lib/; fi
+	mkdir -p $(PREFIX)/include/uWS
+	cp src/*.h $(PREFIX)/include/uWS/
 .PHONY: installDarwin
 installDarwin:
-	cp libuWS.dylib /usr/local/lib/
-	mkdir -p /usr/local/include/uWS
-	cp src/*.h /usr/local/include/uWS/
+	$(eval PREFIX ?= /usr/local)
+	mkdir -p $(PREFIX)/lib
+	cp libuWS.dylib $(PREFIX)/lib/
+	mkdir -p $(PREFIX)/include/uWS
+	cp src/*.h $(PREFIX)/include/uWS/
 .PHONY: clean
 clean:
 	rm -f libuWS.so


### PR DESCRIPTION
This change is being proposed in order to include µWS in the Homebrew package manager. Specifically, it's been requested that the Makefile be able to accept commands such as

```
make install PREFIX=/usr/local/Cellar/microws/0.14.4
```

Installation prefix still defaults to `/usr` on Linux and `/usr/local` on Darwin if no prefix is set.