### PR TITLE
Small fix for Epoll version of Async

### DIFF
--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -243,7 +243,7 @@ struct Async : Poll {
         Poll::stop(loop);
         ::close(state.fd);
         Poll::close(loop, [](Poll *p) {
-            delete p;
+            delete (Async*) p;
         });
     }
 

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -243,7 +243,7 @@ struct Async : Poll {
         Poll::stop(loop);
         ::close(state.fd);
         Poll::close(loop, [](Poll *p) {
-            delete (Async*) p;
+            delete (Async *) p;
         });
     }
 


### PR DESCRIPTION
In Epoll version of Async::close(), delete itself as Async* instead of Poll*