### PR TITLE
make clear to call bind() from global namespace

### DIFF
--- a/src/Node.h
+++ b/src/Node.h
@@ -172,7 +172,7 @@ public:
         int enabled = true;
         setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled));
 
-        if (bind(listenFd, listenAddr->ai_addr, listenAddr->ai_addrlen) || ::listen(listenFd, 512)) {
+        if (::bind(listenFd, listenAddr->ai_addr, listenAddr->ai_addrlen) || ::listen(listenFd, 512)) {
             netContext->closeSocket(listenFd);
             freeaddrinfo(result);
             return true;


### PR DESCRIPTION
small fix to make clear `bind` is called from a global namespace.
this fixes the issue if you use `using namespace std;` in your program.