### PR TITLE
Add port info in HTTP Host header

### DIFF
--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -1,6 +1,7 @@
 #include "Hub.h"
 #include "HTTPSocket.h"
 #include <openssl/sha.h>
+#include <string>
 
 namespace uWS {
 
@@ -173,7 +174,7 @@ void Hub::connect(std::string uri, void *user, std::map<std::string, std::string
                                      "Upgrade: websocket\r\n"
                                      "Connection: Upgrade\r\n"
                                      "Sec-WebSocket-Key: " + randomKey + "\r\n"
-                                     "Host: " + hostname + "\r\n" +
+                                     "Host: " + hostname + ":" + std::to_string(port) + "\r\n"
                                      "Sec-WebSocket-Version: 13\r\n";
 
             for (std::pair<std::string, std::string> header : extraHeaders) {


### PR DESCRIPTION
From the RFC 2616, Section 14.23 ([check it](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23)):

> The Host request-header field specifies the Internet host and port number of the resource being requested, as obtained from the original URI...

and 

> A "host" without any trailing port information implies the default port for the service requested

It seems that you are not specifying the port in the Host Header when creating your upgrade HTTP request, which is causing the connection to drop on some servers.