### PR TITLE
Make members accessible in derived class

### DIFF
--- a/src/Extensions.h
+++ b/src/Extensions.h
@@ -15,7 +15,7 @@ enum Options : unsigned int {
 
 template <bool isServer>
 class ExtensionsNegotiator {
-private:
+protected:
     int options;
 public:
     ExtensionsNegotiator(int wantedOptions);

--- a/src/Group.h
+++ b/src/Group.h
@@ -16,7 +16,7 @@ enum ListenOptions {
 struct Hub;
 
 template <bool isServer>
-struct WIN32_EXPORT Group : private uS::NodeData {
+struct WIN32_EXPORT Group : protected uS::NodeData {
 protected:
     friend struct Hub;
     friend struct WebSocket<isServer>;

--- a/src/HTTPSocket.h
+++ b/src/HTTPSocket.h
@@ -126,7 +126,7 @@ struct WIN32_EXPORT HttpSocket : uS::Socket {
                  size_t extensionsLength, const char *subprotocol,
                  size_t subprotocolLength, bool *perMessageDeflate);
 
-private:
+protected:
     friend struct uS::Socket;
     friend struct HttpResponse;
     friend struct Hub;

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -10,7 +10,7 @@
 
 namespace uWS {
 
-struct WIN32_EXPORT Hub : private uS::Node, public Group<SERVER>, public Group<CLIENT> {
+struct WIN32_EXPORT Hub : protected uS::Node, public Group<SERVER>, public Group<CLIENT> {
 protected:
     struct ConnectionData {
         std::string path;

--- a/src/Networking.h
+++ b/src/Networking.h
@@ -157,7 +157,7 @@ struct Context {
 namespace TLS {
 
 class WIN32_EXPORT Context {
-private:
+protected:
     SSL_CTX *context = nullptr;
     std::shared_ptr<std::string> password;
 

--- a/src/Node.h
+++ b/src/Node.h
@@ -13,7 +13,7 @@ enum ListenOptions : int {
 };
 
 class WIN32_EXPORT Node {
-private:
+protected:
     template <void C(Socket *p, bool error)>
     static void connect_cb(Poll *p, int status, int events) {
         C((Socket *) p, status < 0);
@@ -71,7 +71,6 @@ private:
         } while ((clientFd = netContext->acceptSocket(serverFd)) != INVALID_SOCKET);
     }
 
-protected:
     Loop *loop;
     NodeData *nodeData;
     std::recursive_mutex asyncMutex;

--- a/src/WebSocketProtocol.h
+++ b/src/WebSocketProtocol.h
@@ -62,7 +62,7 @@ public:
     static const unsigned int MEDIUM_MESSAGE_HEADER = isServer ? 8 : 4;
     static const unsigned int LONG_MESSAGE_HEADER = isServer ? 14 : 10;
 
-private:
+protected:
     static inline bool isFin(char *frame) {return *((unsigned char *) frame) & 128;}
     static inline unsigned char getOpCode(char *frame) {return *((unsigned char *) frame) & 15;}
     static inline unsigned char payloadLength(char *frame) {return ((unsigned char *) frame)[1] & 127;}


### PR DESCRIPTION
Hi,

I want to use uWebSockets as a websocket client from behind a proxy.
To implement this, I overrided [``connect``](https://github.com/otamachan/uWS_proxy/blob/2454ff8cc30bbfe77dab90dc580f36a269524944/src/ProxyHub.cpp#L102) method of ``Hub`` class and made a [``ProxyHttpSocket``](https://github.com/otamachan/uWS_proxy/blob/8f9e1a5e15737839b7b86eeaa391b2aa9d8f784e/src/ProxyHTTPSocket.h) class derived from ``HttpSocket`` class to communicate with a proxy server to establish a connection. Unfortunately  some of the members are not accessible in a derived class. This PR makes them accessible.

A full sample is [here](https://github.com/otamachan/uWS_proxy).

If you know a better way to use uWebSockets behind a proxy, please let me know.

Thanks in advance.