### PR TITLE
Support external event loops via non-blocking poll() alt. to run()

### DIFF
--- a/src/Asio.h
+++ b/src/Asio.h
@@ -22,6 +22,10 @@ struct Loop : boost::asio::io_service {
     void run() {
         boost::asio::io_service::run();
     }
+
+    void poll() {
+    	boost::asio::io_service::poll();
+    }
 };
 
 struct Timer {

--- a/src/Asio.h
+++ b/src/Asio.h
@@ -24,7 +24,7 @@ struct Loop : boost::asio::io_service {
     }
 
     void poll() {
-    	boost::asio::io_service::poll();
+        boost::asio::io_service::poll();
     }
 };
 

--- a/src/Epoll.cpp
+++ b/src/Epoll.cpp
@@ -58,6 +58,8 @@ void Loop::doEpoll(int epollTimeout) {
 }
 
 void Loop::run() {
+    // updated for consistency with libuv impl. behaviour
+    timepoint = std::chrono::system_clock::now();
     while (numPolls) {
         doEpoll(delay);
     }
@@ -66,6 +68,9 @@ void Loop::run() {
 void Loop::poll() {
     if (numPolls) {
         doEpoll(0);
+    } else {
+        // updated for consistency with libuv impl. behaviour
+        timepoint = std::chrono::system_clock::now();
     }
 }
 

--- a/src/Epoll.cpp
+++ b/src/Epoll.cpp
@@ -9,55 +9,64 @@ std::recursive_mutex cbMutex;
 void (*callbacks[16])(Poll *, int, int);
 int cbHead = 0;
 
-void Loop::run() {
-    timepoint = std::chrono::system_clock::now();
-    while (numPolls) {
-        for (std::pair<Poll *, void (*)(Poll *)> c : closing) {
-            numPolls--;
+void Loop::doEpoll(int epollTimeout) {
+    for (std::pair<Poll *, void (*)(Poll *)> c : closing) {
+        numPolls--;
 
-            c.second(c.first);
+        c.second(c.first);
 
-            if (!numPolls) {
-                closing.clear();
-                return;
-            }
-        }
-        closing.clear();
-
-        int numFdReady = epoll_wait(epfd, readyEvents, 1024, delay);
-        timepoint = std::chrono::system_clock::now();
-
-        if (preCb) {
-            preCb(preCbData);
-        }
-
-        for (int i = 0; i < numFdReady; i++) {
-            Poll *poll = (Poll *) readyEvents[i].data.ptr;
-            int status = -bool(readyEvents[i].events & EPOLLERR);
-            callbacks[poll->state.cbIndex](poll, status, readyEvents[i].events);
-        }
-
-        while (timers.size() && timers[0].timepoint < timepoint) {
-            Timer *timer = timers[0].timer;
-            cancelledLastTimer = false;
-            timers[0].cb(timers[0].timer);
-
-            if (cancelledLastTimer) {
-                continue;
-            }
-
-            int repeat = timers[0].nextDelay;
-            auto cb = timers[0].cb;
-            timers.erase(timers.begin());
-            if (repeat) {
-                timer->start(cb, repeat, repeat);
-            }
-        }
-
-        if (postCb) {
-            postCb(postCbData);
+        if (!numPolls) {
+            closing.clear();
+            return;
         }
     }
+    closing.clear();
+
+    int numFdReady = epoll_wait(epfd, readyEvents, 1024, epollTimeout);
+    timepoint = std::chrono::system_clock::now();
+
+    if (preCb) {
+        preCb(preCbData);
+    }
+
+    for (int i = 0; i < numFdReady; i++) {
+        Poll *poll = (Poll *) readyEvents[i].data.ptr;
+        int status = -bool(readyEvents[i].events & EPOLLERR);
+        callbacks[poll->state.cbIndex](poll, status, readyEvents[i].events);
+    }
+
+    while (timers.size() && timers[0].timepoint < timepoint) {
+        Timer *timer = timers[0].timer;
+        cancelledLastTimer = false;
+        timers[0].cb(timers[0].timer);
+
+        if (cancelledLastTimer) {
+            continue;
+        }
+
+        int repeat = timers[0].nextDelay;
+        auto cb = timers[0].cb;
+        timers.erase(timers.begin());
+        if (repeat) {
+            timer->start(cb, repeat, repeat);
+        }
+    }
+
+    if (postCb) {
+        postCb(postCbData);
+    }
+}
+
+void Loop::run() {
+    while (numPolls) {
+    	doEpoll(delay);
+    }
+}
+
+void Loop::poll() {
+	if (numPolls) {
+		doEpoll(0);
+	}
 }
 
 }

--- a/src/Epoll.cpp
+++ b/src/Epoll.cpp
@@ -59,14 +59,14 @@ void Loop::doEpoll(int epollTimeout) {
 
 void Loop::run() {
     while (numPolls) {
-    	doEpoll(delay);
+        doEpoll(delay);
     }
 }
 
 void Loop::poll() {
-	if (numPolls) {
-		doEpoll(0);
-	}
+    if (numPolls) {
+        doEpoll(0);
+    }
 }
 
 }

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -34,7 +34,7 @@ struct Loop {
     int epfd;
     int numPolls = 0;
     bool cancelledLastTimer;
-    int delay = -1;
+    int delay = -1;  // delay to next timer expiry, or -1 if no timers pending
     epoll_event readyEvents[1024];
     std::chrono::system_clock::time_point timepoint;
     std::vector<Timepoint> timers;
@@ -58,7 +58,11 @@ struct Loop {
         delete this;
     }
 
+    void doEpoll(int epollTimeout);
+
     void run();
+
+    void poll();
 
     int getEpollFd() {
         return epfd;

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -67,6 +67,7 @@ public:
     }
 
     using uS::Node::run;
+    using uS::Node::poll;
     using uS::Node::getLoop;
     using Group<SERVER>::onConnection;
     using Group<CLIENT>::onConnection;

--- a/src/Libuv.h
+++ b/src/Libuv.h
@@ -24,6 +24,10 @@ struct Loop : uv_loop_t {
     void run() {
         uv_run(this, UV_RUN_DEFAULT);
     }
+
+    void poll() {
+        uv_run(this, UV_RUN_NOWAIT);
+    }
 };
 
 struct Async {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -64,6 +64,10 @@ void Node::run() {
     loop->run();
 }
 
+void Node::poll() {
+    loop->poll();
+}
+
 Node::~Node() {
     delete [] nodeData->recvBufferMemoryBlock;
     SSL_CTX_free(nodeData->clientContext);

--- a/src/Node.h
+++ b/src/Node.h
@@ -79,7 +79,12 @@ protected:
 public:
     Node(int recvLength = 1024, int prePadding = 0, int postPadding = 0, bool useDefaultLoop = false);
     ~Node();
+
+    /* Blocking */
     void run();
+
+    /* Non-blocking */
+    void poll();
 
     Loop *getLoop() {
         return loop;


### PR DESCRIPTION
For use in applications that already have a primary event loop, so they cannot call blocking run(). They may instead call poll() within this loop to delegate to uWebSocket's secondary event loop (whether Asio, libuv or epoll). It is assumed that this will be called very frequently, e.g. "busy spin".