### PR TITLE
Templatize uS::Timer::start to accept lambdas (Linux, gcc 5.4)

### DIFF
--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -77,7 +77,8 @@ struct Timer {
         this->loop = loop;
     }
 
-    void start(void (*cb)(Timer *), int timeout, int repeat) {
+	template<typename Func>
+    void start(Func cb, int timeout, int repeat) {
         loop->timepoint = std::chrono::system_clock::now();
         std::chrono::system_clock::time_point timepoint = loop->timepoint + std::chrono::milliseconds(timeout);
 


### PR DESCRIPTION
At least with Linux, GCC 5.4, the Timer::start function doesn't accept a lamda parameter. This change fixes that.