### PR TITLE
redesign Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,33 @@
-osx_image: xcode7.3
-os:
-  - osx
-script: brew install --force openssl libuv && make && make install && make tests && time ./testsBin
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      addons:
+        apt:
+          packages:
+            - tree
+            - libuv-dev
+    - os: osx
+      osx_image: xcode7.3
+
+install:
+  - 'if [[ "${TRAVIS_OS_NAME}" == "osx" ]] ; then brew update && brew install --force openssl libuv tree ; fi'
+
+script:
+  - 'set -e'
+  - 'export PREFIX="/tmp/install"'
+  - 'export MAKEFLAGS="-j8"'
+
+  - 'make'
+
+  - 'make install'
+  - 'tree "${PREFIX}"'
+
+  - 'make tests'
+  - 'time $([[ "${TRAVIS_OS_NAME}" == "linux" ]] && echo "catchsegv") ./testsBin'
+
+notifications:
+    email: false


### PR DESCRIPTION
This is a followup of #760. I cut it down by 16 SLOC and it is now at reasonable size, reasonable readability and reasonable functionality. There are just 5 blank lines which could be nuked eventually at the cost of decreased readability. There are also no targets specialized for some platforms anymore, everything is unified with minimal branching for Darwin.

Abilities gained:

- override default CXXFLAGS, useful for distro packagers
- specify own CXXLD, {CXX,LD}FLAGS, LDLIBS, RM
- specify own library names, useful for someone who wants to specify SONAME, like Debian packagers
- build static library
- build object files separately from linking/archiving
- ability to use jobserver
- faster build time thanks to parallel compilation
- test binary gets cleaned

Bugs fixed:

- CFLAGS is no longer used for CXX

Other PRs closed:

- https://github.com/uNetworking/uWebSockets/pull/744