### PR TITLE
Add support for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+*.so
+testsBin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.0)
+project(uWS)
+
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+# Default to shared libs if not set
+if (NOT DEFINED BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS ON)
+endif()
+if (BUILD_SHARED_LIBS)
+    message("-- building shared libs")
+else()
+    message("-- building static libs")
+endif()
+
+# REVISIT: maybe should default to Debug, and give installation
+#          notes for building release?
+# Default to release build if not set
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+message("-- build type: ${CMAKE_BUILD_TYPE}")
+
+# Build uWebSockets Library
+add_library(uWS
+    src/Extensions.cpp
+    src/Group.cpp
+    src/Networking.cpp
+    src/Hub.cpp
+    src/Node.cpp
+    src/WebSocket.cpp
+    src/HTTPSocket.cpp
+    src/Socket.cpp
+    src/Epoll.cpp)
+target_compile_options(uWS PUBLIC -std=c++11)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    message("-- stripping library")
+    target_compile_options(uWS PUBLIC -s)
+endif()
+
+if (USE_LTO)
+    message("-- using LTO")
+    # CMake 3.9 supports "INTERPROCEDURAL_OPTIMIZATION" property, but set it
+    # manually for now
+    # set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    # set_target_properties(uWS PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+    target_compile_options(uWS PUBLIC -flto)
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # TODO: clang doesn't support this flag?
+        target_compile_options(uWS PUBLIC -fno-fat-lto-objects)
+    endif()
+endif()
+
+
+# Build Test Binary
+
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Z REQUIRED)
+find_package(Libuv REQUIRED)
+
+add_executable(testsBin tests/main.cpp)
+target_include_directories(testsBin PRIVATE src/)
+target_link_libraries(testsBin PRIVATE uWS)
+target_link_libraries(testsBin PRIVATE ${OPENSSL_LIBRARIES})
+target_link_libraries(testsBin PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(testsBin PRIVATE ${Z_LIBRARY})
+target_link_libraries(testsBin PRIVATE ${LIBUV_LIBRARIES})
+
+# "make install" support
+# XXX: the old Makefile would try $PREFIX/lib64 first if present, do we want
+#      to preserve that behavior?
+install(TARGETS uWS DESTINATION lib)
+install(DIRECTORY src/ DESTINATION include/uWS FILES_MATCHING PATTERN "*.h")

--- a/cmake/modules/FindLibuv.cmake
+++ b/cmake/modules/FindLibuv.cmake
@@ -1,0 +1,33 @@
+#=============================================================================
+#  Copyright 2016 The Luvit Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#=============================================================================
+# Locate libuv library
+# This module defines
+#  LIBUV_FOUND, if false, do not try to link to libuv
+#  LIBUV_LIBRARIES
+#  LIBUV_INCLUDE_DIR, where to find uv.h
+
+FIND_PATH(LIBUV_INCLUDE_DIR NAMES uv.h)
+FIND_LIBRARY(LIBUV_LIBRARIES NAMES uv libuv)
+
+if(WIN32)
+  list(APPEND LIBUV_LIBRARIES iphlpapi)
+  list(APPEND LIBUV_LIBRARIES psapi)
+  list(APPEND LIBUV_LIBRARIES userenv)
+  list(APPEND LIBUV_LIBRARIES ws2_32)
+endif()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUV DEFAULT_MSG LIBUV_LIBRARIES LIBUV_INCLUDE_DIR)

--- a/cmake/modules/FindZ.cmake
+++ b/cmake/modules/FindZ.cmake
@@ -1,0 +1,49 @@
+# Try to find zlib
+# Once done, this will define
+#
+# Z_FOUND          - system has zlib
+# Z_INCLUDE_DIRS   - zlib include directories
+# Z_LIBRARY        - zlib library
+# Z_LIBRARY_STATIC - static zlib library
+
+include(FindPackageHandleStandardArgs)
+
+if(Z_INCLUDE_DIRS AND Z_LIBRARY AND Z_LIBRARY_STATIC)
+    set(Z_FIND_QUIETLY TRUE)
+else()
+    find_path(
+        Z_INCLUDE_DIR
+        NAMES zlib.h
+        HINTS ${Z_ROOT_DIR}
+        PATH_SUFFIXES include)
+
+    find_library(
+        Z_LIBRARY
+        NAMES z
+        HINTS ${Z_ROOT_DIR}
+        PATH_SUFFIXES ${LIBRARY_PATH_PREFIX})
+
+    set(Z_INCLUDE_DIRS ${Z_INCLUDE_DIR})
+
+    if( MacOSX )
+        find_package_handle_standard_args(
+            z
+            DEFAULT_MSG
+            Z_LIBRARY Z_INCLUDE_DIR)
+
+        mark_as_advanced(Z_LIBRARY Z_INCLUDE_DIR)
+    else ()
+        find_library(
+            Z_LIBRARY_STATIC
+            NAMES libz.a
+            HINTS ${Z_ROOT_DIR}
+            PATH_SUFFIXES ${LIBRARY_PATH_PREFIX})
+
+        find_package_handle_standard_args(
+            z
+            DEFAULT_MSG
+            Z_LIBRARY Z_INCLUDE_DIR Z_LIBRARY_STATIC)
+
+        mark_as_advanced(Z_LIBRARY Z_LIBRARY_STATIC Z_INCLUDE_DIR)
+    endif()
+endif()


### PR DESCRIPTION
If you would like to use it, here is a cmake build implementation.  It is annoying to add another dependency, but cmake is sort-of the leader in the C++ build space so people should have it.

I am getting a slightly large .so.  Based on output from nm, I believe both libs have the same symbols.   So my guess is that because cmake is doing an incremental build, whereas the Makefile passes all .cpp in together, it is getting a little better optimization.  I threw in LTO support, but that still doesn't get the size below what the Makefile generates.  If you want to check the flags being used for the build, you can do "make VERBOSE=1".

-----------------------------------------------------------------------------------------------------

Uses c++ to build libuWS library as well as the tests.

Basic Usage (Linux Makefiles):
    $ mkdir build  # out-of-source builds are encouraged
    $ cd build/
    $ cmake ..
    $ make -j
    $ make install

Windows Project Generation:
    $ mkdir build
    $ cd build/
    $ cmake -G "Visual Studio Visual Studio 15 2017 Win64" ..

XCode Project Generation:
    $ mkdir build
    $ cd build/
    $ cmake -G "Xcode" ..

Other generators are listed here: https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html.

REVISIT: On Linux, switch to Ninja as default?

Other options:
    +CMAKE_BUILD_TYPE={Debug, Release, MinSizeRel}
    +BUILD_SHARED_LIBS={ON,OFF}
    +USE_LTO={ON,OFF}

    e.g. $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DUSE_LTO=ON ..

clang 3.8 is complaining about the "-s" strip flag, so it only gets
added if the compiler is gcc.

TODO: check on strip support on Windows

TODO: setup cpack and ctest

Note: I do not have access to OS X to test, but cmake *should* just
work.