### PR TITLE
Fix SSL library init order

### DIFF
--- a/src/Networking.cpp
+++ b/src/Networking.cpp
@@ -27,13 +27,13 @@ Context::~Context()
     }
 }
 
-struct Init {
-    Init() {SSL_library_init();}
-    ~Init() {/*EVP_cleanup();*/}
-} init;
-
 Context createContext(std::string certChainFileName, std::string keyFileName, std::string keyFilePassword)
 {
+    static struct Init {
+        Init() {SSL_library_init();}
+        ~Init() {/*EVP_cleanup();*/}
+    } init;
+    
     Context context(SSL_CTX_new(SSLv23_server_method()));
     if (!context.context) {
         return nullptr;


### PR DESCRIPTION
It was possible for it to not have been initialized yet if we're calling createContext in the initialization of a global variable in another file, since there's nothing that guarantees the initialization order between global variables in different files.

There's also another init further down in this file related to Windows, but I haven't been using uWebSockets on Windows that much to hit an issue with that yet.