### PR TITLE
loop through the list returned by getaddrinfo

### DIFF
--- a/src/Networking.cpp
+++ b/src/Networking.cpp
@@ -27,13 +27,13 @@ Context::~Context()
     }
 }
 
-struct Init {
-    Init() {SSL_library_init();}
-    ~Init() {/*EVP_cleanup();*/}
-} init;
-
 Context createContext(std::string certChainFileName, std::string keyFileName, std::string keyFilePassword)
 {
+    static struct Init {
+        Init() {SSL_library_init();}
+        ~Init() {/*EVP_cleanup();*/}
+    } init;
+    
     Context context(SSL_CTX_new(SSLv23_server_method()));
     if (!context.context) {
         return nullptr;


### PR DESCRIPTION
getaddrinfo returns a linked list, you should loop through it and try entries until you succeed:
http://beej.us/guide/bgnet/html/multi/syscalls.html#getaddrinfo

Here's an example of doing it properly. Curl tries to connect to localhost, getaddrinfo returns the list with ::1 as the first entry, connection to it fails and curl proceeds to the next entry which is good old IPv4 127.0.0.1 and it succeeds:
```
curl -v localhost:8000
* Rebuilt URL to: localhost:8000/
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
...
```