### PR TITLE
Close all HttpSockets on Group->close/terminate() too, to avoid hanging server

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -239,18 +239,24 @@ void Group<isServer>::broadcast(const char *message, size_t length, OpCode opCod
 
 template <bool isServer>
 void Group<isServer>::terminate() {
+    stopListening();
     forEach([](uWS::WebSocket<isServer> *ws) {
         ws->terminate();
     });
-    stopListening();
+    forEachHttpSocket([](HttpSocket<isServer> *httpSocket) {
+        httpSocket->terminate();
+    });
 }
 
 template <bool isServer>
 void Group<isServer>::close(int code, char *message, size_t length) {
+    stopListening();
     forEach([code, message, length](uWS::WebSocket<isServer> *ws) {
         ws->close(code, message, length);
     });
-    stopListening();
+    forEachHttpSocket([](HttpSocket<isServer> *httpSocket) {
+        httpSocket->shutdown();
+    });
     if (timer) {
         timer->stop();
         timer->close();


### PR DESCRIPTION
When closing the Server currently only the WebSockets are closed, but not the HttpSockets.

Yes, idle HttpSockets are terminated after 1-2 secs by the timer in Group::addHttpSocket() ... BUT: If the client sends an Upgrade header within this timeout, it is added as a new WebSocket connection and keeps the server running until the client closes the connection.

I'm not sure, if this is the best way to fix this issue or if there are more things to do. But in some short tests it worked fine now.