### PR TITLE
Shutdown HttpSocket immediately on end()

### DIFF
--- a/src/HTTPSocket.h
+++ b/src/HTTPSocket.h
@@ -264,6 +264,8 @@ struct HttpResponse {
             }
 
             freeResponse(httpSocket);
+
+            // TODO: httpSocket->shutdown() when finished sending?
         }
     }
 


### PR DESCRIPTION
When answering a HttpRequest with `res->end()`, the connection is currently not closed immediately but 1-2 secs later by the timeout in `Group::addHttpSocket()`. Normally this works fine, but when sending custom headers (with `res->hasHead = true;`) without a Content-Length-Header, the HTTP client has to wait until the server closes the connection.

For some simple (error-)responses it's unhandy to calculate the Content-Length. Wouldn't it be better, that `end()` always closes the connection immediately after the data has been sent by default?

I currently don't have an idea where to implement this. And I currently don't understand what's the difference between `HttpResponse::write()` and `HttpResponse::end()` as it is implemented completely different. Intuitively I would think, `write()` does the same as `end()` but `end()` closes the connection afterwards, or am I completely wrong here?

```
    h.onHttpRequest([&](HttpResponse *res, HttpRequest req, char *data, size_t length,
                        size_t remainingBytes) {
        res->hasHead = true;
        res->end(response.data(), response.length());
    });
```

BTW: I loved to read "if v0.15 ever happens HTTP will be a major focus." ;-)