### PR TITLE
Support OpenSSL 1.1.0 and TLS for networking

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -55,8 +55,14 @@ Node::Node(int recvLength, int prePadding, int postPadding, bool useDefaultLoop)
         nodeData->preAlloc[i] = nullptr;
     }
 
+#if OPENSSL_VERSION_AT_LEAST(1, 1)
+    // If we're compiling against OpenSSL 1.1.0, use TLS instead of SSLv23
     nodeData->clientContext = SSL_CTX_new(TLS_client_method());
     SSL_CTX_set_min_proto_version(nodeData->clientContext, TLS1_VERSION);
+#else
+    nodeData->clientContext = SSL_CTX_new(SSLv23_client_method());
+    SSL_CTX_set_options(nodeData->clientContext, SSL_OP_NO_SSLv3);
+#endif
 }
 
 void Node::run() {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -55,8 +55,8 @@ Node::Node(int recvLength, int prePadding, int postPadding, bool useDefaultLoop)
         nodeData->preAlloc[i] = nullptr;
     }
 
-    nodeData->clientContext = SSL_CTX_new(SSLv23_client_method());
-    SSL_CTX_set_options(nodeData->clientContext, SSL_OP_NO_SSLv3);
+    nodeData->clientContext = SSL_CTX_new(TLS_client_method());
+    SSL_CTX_set_min_proto_version(nodeData->clientContext, TLS1_VERSION);
 }
 
 void Node::run() {


### PR DESCRIPTION
~~This effectively drops support for OpenSSL 1.0.0 since it uses stuff only added in OpenSSL 1.1.0, and should keep behaviour almost the same as before.~~ EDIT: Uses a compile-time macro to decide whether to use OpenSSL 1.0.0-compatible APIs or OpenSSL 1.1.0-compatible APIs.

With this change, SSLv2 support is lost when compiling against OpenSSL 1.1.0 as it was removed, but I don't think that's a large enough issue to worry about in the long run.