### PR TITLE
Call shutdown() also when other direction is already closed

### DIFF
--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -282,6 +282,7 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
         httpSocket->cancelTimeout();
     }
 
+    httpSocket->template shutdown();
     httpSocket->template closeSocket<HttpSocket<isServer>>();
 
     while (!httpSocket->messageQueue.empty()) {

--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -296,6 +296,7 @@ void WebSocket<isServer>::onEnd(uS::Socket *s) {
         webSocket->cancelTimeout();
     }
 
+    webSocket->template shutdown();
     webSocket->template closeSocket<WebSocket<isServer>>();
 
     while (!webSocket->messageQueue.empty()) {


### PR DESCRIPTION
This avoids vanishing of the SSL session cache. When calling SSL_free() on a non-shutdowned connection, the session is considered bad, and removed from the session cache:

> the SSL_SENT_SHUTDOWN flag is set and a currently open session is considered closed and good and will be kept in the session cache for further reuse.

https://www.openssl.org/docs/man1.0.2/ssl/SSL_shutdown.html

You can verify this with https://www.ssllabs.com/ssltest/index.html ... and check for:

> Session resumption (caching): Yes