### PR TITLE
suppress uninitialized warning

### DIFF
--- a/src/Libuv.h
+++ b/src/Libuv.h
@@ -102,6 +102,7 @@ struct Poll {
     Poll(Loop *loop, uv_os_sock_t fd) {
         uv_poll = new uv_poll_t;
         uv_poll_init_socket(loop, uv_poll, fd);
+        cb = nullptr;
     }
 
     Poll(Poll &&other) {


### PR DESCRIPTION
cb is not initialized, which will generate a warning/error at compile.