### PR TITLE
Moved UV_READABLE, UV_WRITABLE, and uv_os_sock_t into uS namespace

### DIFF
--- a/src/Asio.h
+++ b/src/Asio.h
@@ -3,11 +3,11 @@
 
 #include <boost/asio.hpp>
 
+namespace uS {
+
 typedef boost::asio::ip::tcp::socket::native_handle_type uv_os_sock_t;
 static const int UV_READABLE = 1;
 static const int UV_WRITABLE = 2;
-
-namespace uS {
 
 struct Loop : boost::asio::io_service {
 
@@ -186,6 +186,14 @@ struct Poll {
         socket = nullptr;
     }
 };
+
+}
+
+namespace uWS {
+
+using uS::uv_os_sock_t;
+using uS::UV_READABLE;
+using uS::UV_WRITABLE;
 
 }
 

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -10,11 +10,11 @@
 #include <vector>
 #include <mutex>
 
+namespace uS {
+
 typedef int uv_os_sock_t;
 static const int UV_READABLE = EPOLLIN;
 static const int UV_WRITABLE = EPOLLOUT;
-
-namespace uS {
 
 struct Poll;
 struct Timer;
@@ -259,6 +259,14 @@ struct Async : Poll {
         return data;
     }
 };
+
+}
+
+namespace uWS {
+
+using uS::uv_os_sock_t;
+using uS::UV_READABLE;
+using uS::UV_WRITABLE;
 
 }
 


### PR DESCRIPTION
At present, the declarations of UV_READABLE, UV_WRITABLE, and uv_os_sock_t make it not possible to include both `uv.h` and uWS files like `Hub.h` together in the same source file (if one is using the epoll or asio backend) as these definitions conflict.

This PR Is the most minimal set of changes to remove this conflict. Perhaps it would be better to rename as follows: `UV_READABLE` -> `uS::READABLE`, `UV_WRITABLE` -> `uS::WRITABLE`, and `uv_sock_t` -> `us_os_sock_t`, which I would also be happy to do.