### PR TITLE
Epoll Bug Fixes - Timer Resolution Accuracy Improved

### DIFF
--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -131,7 +131,6 @@ struct Timer {
 // 4 bytes
 struct Poll {
 protected:
-
     struct {
         int fd : 28;
         unsigned int cbIndex : 4;

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -131,7 +131,6 @@ struct Timer {
 // 4 bytes
 struct Poll {
 protected:
-//	void *data;
 
     struct {
         int fd : 28;

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -34,6 +34,7 @@ struct Loop {
     int epfd;
     int numPolls = 0;
     bool cancelledLastTimer;
+    Timer *processingTimer = NULL; // the timer we're currently processing a callback for
     int delay = -1;  // delay to next timer expiry, or -1 if no timers pending
     epoll_event readyEvents[1024];
     std::chrono::system_clock::time_point timepoint;
@@ -113,7 +114,8 @@ struct Timer {
             }
             pos++;
         }
-        loop->cancelledLastTimer = true;
+
+        if(loop->processingTimer == this) loop->cancelledLastTimer = true;
 
         loop->delay = -1;
         if (loop->timers.size()) {
@@ -129,6 +131,8 @@ struct Timer {
 // 4 bytes
 struct Poll {
 protected:
+//	void *data;
+
     struct {
         int fd : 28;
         unsigned int cbIndex : 4;

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -34,7 +34,7 @@ struct Loop {
     int epfd;
     int numPolls = 0;
     bool cancelledLastTimer;
-    Timer *processingTimer = NULL; // the timer we're currently processing a callback for
+    Timer *processingTimer = nullptr; // the timer we're currently processing a callback for
     int delay = -1;  // delay to next timer expiry, or -1 if no timers pending
     epoll_event readyEvents[1024];
     std::chrono::system_clock::time_point timepoint;
@@ -115,7 +115,9 @@ struct Timer {
             pos++;
         }
 
-        if(loop->processingTimer == this) loop->cancelledLastTimer = true;
+        if(loop->processingTimer == this) {
+            loop->cancelledLastTimer = true;
+        }
 
         loop->delay = -1;
         if (loop->timers.size()) {


### PR DESCRIPTION
Fixed two major bugs with Epoll timers.

1) Rewrote the timer check in Loop::run to reset the next epoll_wait() epollTimeout/delay if there was socket activity but no executed timer. This fixes timer resolution to be very accurate, regardless of i/o activity.

2) Critical bug fix where if while executing a timer callback, the callback stop()'d a different timer, the loop code would "continue" thinking the current timer was stopped. This was because it uses a Loop:: boolean that is global to that context. Added checking to make sure the current processing timer was stopped. The result of this bug would be that the timer would execute a second time immediately.

One other note is that if during the timer check loop your callback triggers the creation of a new Timer that wants to execute immediately (0ms), this entire chain will break, since it relies on a presumed index of [0] after the callback executes. This doesn't matter for my particular usage, because I'd never use timers in this way, but for sake of being super robust, just making full disclosure. That particular usage bug exists in both mine and the original branch.