### PR TITLE
Add method to get all headers on the request

### DIFF
--- a/src/HttpParser.h
+++ b/src/HttpParser.h
@@ -62,6 +62,16 @@ public:
         return std::string_view(nullptr, 0);
     }
 
+    std::map<std::string_view, std::string_view> getHeaders() {
+        std::map<std::string_view, std::string_view> _headers;
+
+        for (Header *h = headers; (++h)->key.length(); ) {
+            _headers.insert(std::pair(h->key, h->value));
+        }
+
+        return _headers;
+    }
+
     std::string_view getUrl() {
         return std::string_view(headers->value.data(), querySeparator);
     }


### PR DESCRIPTION
I would like to be able to get all the headers for a given request, with the intention of being able to add this into the uWebSockets.js repo. [Commit for uWebSocket.js on fork](https://github.com/kyle-mccarthy/uWebSockets.js/commit/feee90b78a5faecbc72c3d098834e4d999a29278).

I want to apologize in advance if I am doing something wrong or a bad way, I don't actually know c++.

