### PR TITLE
fix compile issues

### DIFF
--- a/examples/EchoServer.cpp
+++ b/examples/EchoServer.cpp
@@ -11,6 +11,7 @@ int main() {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024,
+        .idleTimeout = 120,
         /* Handlers */
         .open = [](auto *ws, auto *req) {
 

--- a/examples/EchoServerThreaded.cpp
+++ b/examples/EchoServerThreaded.cpp
@@ -19,6 +19,7 @@ int main() {
                 /* Settings */
                 .compression = uWS::SHARED_COMPRESSOR,
                 .maxPayloadLength = 16 * 1024,
+                .idleTimeout = 120,
                 /* Handlers */
                 .open = [](auto *ws, auto *req) {
 

--- a/src/AsyncSocket.h
+++ b/src/AsyncSocket.h
@@ -30,7 +30,7 @@ struct AsyncSocket {
     template <bool> friend struct HttpContext;
     template <bool, bool> friend struct WebSocketContext;
     friend class TopicTree;
-protected:
+//protected:
 
     /* Get loop data for socket */
     LoopData *getLoopData() {


### PR DESCRIPTION
1. Fix wrong format of brace-enclosed initialization of WebSocketBehavior in examples
2. In AsyncSocket some member methods are declared as protected, but later call by object