### PR TITLE
Fixed missing definition of WIN32_EXPORT

### DIFF
--- a/src/WebSocketProtocol.h
+++ b/src/WebSocketProtocol.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <libusockets_new.h>
 
 namespace uWS {
 


### PR DESCRIPTION
Fixed compiler errors when including WebSocketProtocol.h alone.