### PR TITLE
Fix build in Visual Studio 2017/2019 and GCC >= 7.2.0

### DIFF
--- a/src/AsyncSocket.h
+++ b/src/AsyncSocket.h
@@ -97,7 +97,7 @@ struct AsyncSocket {
     std::string_view getRemoteAddress() {
         static thread_local char buf[16];
         int ipLength = 16;
-        us_new_socket_remote_address(SSL, (us_new_socket_t *) this, buf, &ipLength);
+        us_new_socket_remote_address(SSL, (us_new_socket_t *) this, this->buf, &ipLength);
         return std::string_view(buf, ipLength);
     }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -59,7 +59,7 @@ private:
     /* Init the HttpContext by registering libusockets event handlers */
     HttpContext<SSL> *init() {
         /* Handle socket connections */
-        us_new_socket_context_on_open(SSL, getSocketContext(), [](auto *s, int is_client, char *ip, int ip_length) {
+        us_new_socket_context_on_open(SSL, getSocketContext(), [](auto *s, int is_client) {
             /* Any connected socket should timeout until it has a request */
             us_new_socket_timeout(SSL, s, HTTP_IDLE_TIMEOUT_S);
 


### PR DESCRIPTION
Too many arguments in lambda:
```
error C2664:  'void us_new_socket_context_on_open(const int,us_new_socket_context_t *,us_new_socket_t *(__cdecl *)(us_new_socket_t *,int))': cannot convert argument 3 from 'uWS::HttpContext<false>::init::<lambda_1a1e4fd2aa024a7b371578dc5ee59d10>' to 'us_new_socket_t *(__cdecl *)(us_new_socket_t *,int)'
```
Missing `this` keyword:
```
error: there are no arguments to 'us_new_socket_remote_address' that depend on a template parameter, so a declaration of 'us_new_socket_remote_address' must be available [-fpermissive]
             us_new_socket_remote_address(SSL, (us_new_socket_t*)this, buf, &ipLength);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```