### PR TITLE
Clarify getHeader argument meaning

### DIFF
--- a/src/HttpParser.h
+++ b/src/HttpParser.h
@@ -86,9 +86,9 @@ public:
         didYield = yield;
     }
 
-    std::string_view getHeader(std::string_view header) {
+    std::string_view getHeader(std::string_view lowerCasedHeader) {
         for (Header *h = headers; (++h)->key.length(); ) {
-            if (h->key.length() == header.length() && !strncmp(h->key.data(), header.data(), header.length())) {
+            if (h->key.length() == lowerCasedHeader.length() && !strncmp(h->key.data(), lowerCasedHeader.data(), lowerCasedHeader.length())) {
                 return h->value;
             }
         }


### PR DESCRIPTION
I tried to use getHeader method on HttpRequest and found out that it did not perform case insensitive search on headers.

It is specified by [RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1"](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) that headers should be case insensitive:
> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.
