### PR TITLE
Implemented CompressorOptions

### DIFF
--- a/examples/BroadcastingEchoServer.cpp
+++ b/examples/BroadcastingEchoServer.cpp
@@ -10,6 +10,7 @@ int main() {
     uWS::App().ws<PerSocketData>("/*", {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
+        .compressorOptions = {},
         .maxPayloadLength = 16 * 1024,
         .idleTimeout = 10,
         /* Handlers */

--- a/examples/EchoServer.cpp
+++ b/examples/EchoServer.cpp
@@ -10,6 +10,7 @@ int main() {
     uWS::App().ws<PerSocketData>("/*", {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
+        .compressorOptions = {},
         .maxPayloadLength = 16 * 1024,
 	.idleTimeout = 10,
         /* Handlers */

--- a/examples/EchoServerThreaded.cpp
+++ b/examples/EchoServerThreaded.cpp
@@ -18,6 +18,7 @@ int main() {
             uWS::App().ws<PerSocketData>("/*", {
                 /* Settings */
                 .compression = uWS::SHARED_COMPRESSOR,
+                .compressorOptions = {},
                 .maxPayloadLength = 16 * 1024,
                 .idleTimeout = 10,
                 /* Handlers */

--- a/fuzzing/MockedEchoServer.cpp
+++ b/fuzzing/MockedEchoServer.cpp
@@ -19,6 +19,7 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
     app = new uWS::TemplatedApp<false>(uWS::App().ws<PerSocketData>("/*", {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
+        .compressorOptions = {},
         .maxPayloadLength = 16 * 1024,
         .idleTimeout = 10,
         /* Handlers */

--- a/misc/READMORE.md
+++ b/misc/READMORE.md
@@ -86,6 +86,7 @@ Every websocket route has the same pattern and pattern matching as for Http, but
 uWS::App().ws<PerSocketData>("/*", {
     /* Settings */
     .compression = uWS::SHARED_COMPRESSOR,
+    .compressorOptions = {},
     .maxPayloadLength = 16 * 1024,
     .idleTimeout = 10,
     /* Handlers */

--- a/misc/main.cpp
+++ b/misc/main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
     }).ws<PerSocketData>("/*", {
         /* Settings */
         .compression = uWS::DEDICATED_COMPRESSOR,
+        .compressorOptions = {},
         .maxPayloadLength = 16 * 1024 * 1024,
         .idleTimeout = 10,
         /* Handlers */

--- a/src/App.h
+++ b/src/App.h
@@ -87,6 +87,7 @@ public:
 
     struct WebSocketBehavior {
         CompressOptions compression = DISABLED;
+        CompressorOptions compressorOptions;
         int maxPayloadLength = 16 * 1024;
         int idleTimeout = 120;
         fu2::unique_function<void(uWS::WebSocket<SSL, true> *, HttpRequest *)> open = nullptr;
@@ -207,7 +208,7 @@ public:
 
                 /* Initialize websocket with any moved backpressure intact */
                 httpContext->upgradeToWebSocket(
-                            webSocket->init(perMessageDeflate, slidingDeflateWindow, std::move(backpressure))
+                            webSocket->init(perMessageDeflate, slidingDeflateWindow, behavior.compressorOptions, std::move(backpressure))
                             );
 
                 /* Emit open event and start the timeout */

--- a/src/App.h
+++ b/src/App.h
@@ -30,8 +30,7 @@
 
 namespace uWS {
 
-/* Compress options (really more like PerMessageDeflateOptions) */
-enum CompressOptions {
+enum CompressorType {
     /* Compression disabled */
     DISABLED = 0,
     /* We compress using a shared non-sliding window. No added memory usage, worse compression. */
@@ -86,7 +85,7 @@ public:
     }
 
     struct WebSocketBehavior {
-        CompressOptions compression = DISABLED;
+        CompressorType compression = DISABLED;
         CompressorOptions compressorOptions;
         int maxPayloadLength = 16 * 1024;
         int idleTimeout = 120;

--- a/src/PerMessageDeflate.h
+++ b/src/PerMessageDeflate.h
@@ -25,6 +25,11 @@
 
 namespace uWS {
 
+struct CompressorOptions {
+    int windowBits = -15;
+    int memLevel = 8;
+};
+
 /* Do not compile this module if we don't want it */
 #ifdef UWS_NO_ZLIB
 struct ZlibContext {};
@@ -34,6 +39,9 @@ struct InflationStream {
     }
 };
 struct DeflationStream {
+    DeflationStream(CompressorOptions& compressorOptions) {
+    }
+
     std::string_view deflate(ZlibContext *zlibContext, std::string_view raw, bool reset) {
         return raw;
     }
@@ -66,7 +74,16 @@ struct DeflationStream {
     z_stream deflationStream = {};
 
     DeflationStream() {
-        deflateInit2(&deflationStream, 1, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+        CompressorOptions compressorOptions; // use default values
+        init(compressorOptions);
+    }
+
+    DeflationStream(CompressorOptions& compressorOptions) {
+        init(compressorOptions);
+    }
+
+    void init(CompressorOptions& compressorOptions) {
+        deflateInit2(&deflationStream, 1, Z_DEFLATED, compressorOptions.windowBits, compressorOptions.memLevel, Z_DEFAULT_STRATEGY);
     }
 
     /* Deflate and optionally reset */

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -33,8 +33,8 @@ struct WebSocket : AsyncSocket<SSL> {
 private:
     typedef AsyncSocket<SSL> Super;
 
-    void *init(bool perMessageDeflate, bool slidingCompression, std::string &&backpressure) {
-        new (us_socket_ext(SSL, (us_socket_t *) this)) WebSocketData(perMessageDeflate, slidingCompression, std::move(backpressure));
+    void *init(bool perMessageDeflate, bool slidingCompression, CompressorOptions& compressorOptions, std::string &&backpressure) {
+        new (us_socket_ext(SSL, (us_socket_t *) this)) WebSocketData(perMessageDeflate, slidingCompression, compressorOptions, std::move(backpressure));
         return this;
     }
 public:

--- a/src/WebSocketData.h
+++ b/src/WebSocketData.h
@@ -42,12 +42,12 @@ private:
     /* We might have a dedicated compressor */
     DeflationStream *deflationStream = nullptr;
 public:
-    WebSocketData(bool perMessageDeflate, bool slidingCompression, std::string &&backpressure) : AsyncSocketData<false>(std::move(backpressure)), WebSocketState<true>() {
+    WebSocketData(bool perMessageDeflate, bool slidingCompression, CompressorOptions& compressorOptions, std::string &&backpressure) : AsyncSocketData<false>(std::move(backpressure)), WebSocketState<true>() {
         compressionStatus = perMessageDeflate ? ENABLED : DISABLED;
 
         /* Initialize the dedicated sliding window */
         if (perMessageDeflate && slidingCompression) {
-            deflationStream = new DeflationStream;
+            deflationStream = new DeflationStream(compressorOptions);
         }
     }
 


### PR DESCRIPTION
I implemented the CompressorOptions (#926) now for the dedicated-compressor (not for the shared one). Please check if it fits your requirements.

By the way: The negotiation of permessage-deflate options (like max-window-bits) does not need to be changed here - as theese are just hints (which are currently ignored anyway). The actual negotiation of deflate-options is done inside the zlib-protocol. (At least in 0.14 we patched just the deflateInit2() params and it runs fine in production :-))

I also renamed CompressOptions -> CompressorType in a separate commit - to avoid naming confusion.
But it's an incompatible change maybe - it's just a proposal :-)

By the way: I added the new option also to the examples - as in C++<=17 all members have to be initialized. What's your plan here for the future? Just wait for C++20, where you can initialize specific members only? :-)