### PR TITLE
Allow different handlers for GET and WS for same route (#860)

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -135,7 +135,7 @@ public:
         webSocketContext->getExt()->maxPayloadLength = behavior.maxPayloadLength;
         webSocketContext->getExt()->idleTimeout = behavior.idleTimeout;
 
-        return std::move(get(pattern, [webSocketContext, httpContext = this->httpContext, behavior = std::move(behavior)](auto *res, auto *req) mutable {
+        httpContext->onHttp("ws", pattern, [webSocketContext, httpContext = this->httpContext, behavior = std::move(behavior)](auto *res, auto *req) mutable {
 
             /* If we have this header set, it's a websocket */
             std::string_view secWebSocketKey = req->getHeader("sec-websocket-key");
@@ -224,7 +224,8 @@ public:
                 /* Tell the router that we did not handle this request */
                 req->setYield(true);
             }
-        }));
+        });
+        return std::move(*this);
     }
 
     TemplatedApp &&get(std::string pattern, fu2::unique_function<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -142,7 +142,13 @@ private:
 
                 /* Route the method and URL in two passes */
                 typename HttpContextData<SSL>::RouterData routerData = {(HttpResponse<SSL> *) s, httpRequest};
-                if (!httpContextData->router.route(httpRequest->getMethod(), httpRequest->getUrl(), routerData)) {
+
+                std::string_view method = httpRequest->getMethod();
+                if (httpRequest->getHeader("sec-websocket-key").length() == 24) {
+                    method = "ws"; // independent routing for WebSockets
+                }
+
+                if (!httpContextData->router.route(method, httpRequest->getUrl(), routerData)) {
                     /* If first pass failed, we try and match by "any" method */
                     if (!httpContextData->router.route("*", httpRequest->getUrl(), routerData)) {
                         /* If second pass fail, we have to force close this socket as we have no handler for it */


### PR DESCRIPTION
I made a pull-request out of the proposal from @szmarczak (slightly simplified).

Seems to work. Currently I do not see any drawbacks.

Btw.: I didn't fully understand the `req->setYield()` concept of the router, as it would make sense here, when multiple handlers for the same route could be registered.