### PR TITLE
dst size should match whats being copied into it

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -150,7 +150,7 @@ public:
         );
 
         /* We frame the message right here and only pass raw bytes to the pub/subber */
-        char dst[1024];
+        char dst[message.length() + 14];
         size_t dst_length = protocol::formatMessage<true>(dst, message.data(), message.length(), OpCode::TEXT, message.length(), false);
 
         webSocketContextData->topicTree.publish(std::string(topic), dst, dst_length);


### PR DESCRIPTION
Max header value is 14 within `formatMessage`. 
Seeing as dst matches `message.length()` with a header prepended we can make dst as small or large as we want.

Changed this because I got errors when testing large messages