### PR TITLE
Adding example for batch processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXAMPLE_FILES := HelloWorld EchoServer BroadcastingEchoServer
-THREADED_EXAMPLE_FILES := HelloWorldThreaded EchoServerThreaded
+THREADED_EXAMPLE_FILES := HelloWorldThreaded EchoServerThreaded BatchProcessingExample
 override CXXFLAGS += -std=c++17 -Isrc -IuSockets/src
 override LDFLAGS += uSockets/*.o -lz
 

--- a/examples/BatchProcessingExample.cpp
+++ b/examples/BatchProcessingExample.cpp
@@ -1,0 +1,123 @@
+#include "App.h"
+#include <thread>
+#include <algorithm>
+#include <unistd.h>
+#include <queue>
+#include <string>
+
+int running = 1;
+std::mutex qmutex;
+std::queue<uWS::AsyncProcData*> q;
+
+bool finish_request(uWS::AsyncProcData* pd){
+    // calling this function in the separate thread
+    if (pd->procDataMutex.try_lock()){
+        pd->asyncProcStarted = true;
+        pd->out = pd->asyncInput;
+        pd->procDataMutex.unlock();
+        return true;
+    }
+    std::cout << "failed to lock procdatamutex, could not modify procdata" << std::endl;
+    return false;
+}
+
+void thread_2_batch_function(){
+    // calling this function in the separate thread
+    while(running){
+        usleep(100);
+        qmutex.lock();
+        for (int i=0;!q.empty();i++){
+            //std::cout << "thread 2 handling queue now" << std::endl;
+            auto pd = q.front();
+            finish_request(pd);
+            q.pop();
+        }
+        qmutex.unlock();
+    }
+}
+
+
+template <bool SSL>
+void asyncProcCheck(uWS::HttpResponse<SSL>* res){
+    if (res->getProcData()->asyncProcStarted && res->getProcData()->procDataMutex.try_lock()){
+        res->getProcData()->procDataMutex.unlock();
+        uWS::AsyncProcData* pd = res->getProcData();
+        res->end(res->getProcData()->out);
+        delete pd;
+    }
+    else{
+        if (res->getProcData() != nullptr){
+            uWS::Loop* loop = uWS::Loop::get();
+            loop->defer([res](){
+                asyncProcCheck(res);
+            });
+        }
+    }
+}
+
+template <bool SSL>
+void load_queue(uWS::HttpRequest* req, uWS::HttpResponse<SSL>* res, uint count){
+    uWS::AsyncProcData* pd = new uWS::AsyncProcData;
+
+    res->setProcData(pd);
+    //res->getProcData() = pd;
+    pd->asyncProcStarted = false;
+    pd->asyncInput = "This is response number: " + std::to_string(count) + "\n";
+    qmutex.lock();
+    q.push(pd);
+    qmutex.unlock();
+    res->onWritable([res](int offset) {
+        asyncProcCheck(res);
+        // why do we return false?  don't know, it was in AsyncFileStream.h
+        return false;
+    })->onAborted([]() {
+        std::cout << "ABORTED!" << std::endl;
+    });
+    //asyncProcCheck(res);
+    uWS::Loop* loop = uWS::Loop::get();
+    loop->defer([res](){
+        asyncProcCheck(res);
+    });
+}
+
+template <bool SSL>
+void print_q_size(uWS::HttpResponse<SSL>* res){
+    res->end(std::to_string(q.size()));
+}
+
+int main() {
+    std::cout << "thread id for main function is: " << std::this_thread::get_id();
+
+    std::thread t2(thread_2_batch_function);
+    /* Overly simple batch processing app, using multiple threads for input into a queue
+        with a single queue output.  This is to have a simple illustration of the async
+        capabilities of uWebsockets.  It is not as performant as it could be.
+    */
+    std::vector<std::thread *> threads(std::thread::hardware_concurrency());
+
+    std::transform(threads.begin(), threads.end(), threads.begin(), [](std::thread *t) {
+        return new std::thread([]() {
+            std::atomic<uint> count = 0;
+            uWS::App().get("/hello", [&count](auto *res, auto *req) {
+                load_queue(req, res, count++);
+            }).get("/check", [&count](auto *res, auto *req) {
+                print_q_size(res);
+            }).get("/stopbatch", [&count](auto *res, auto *req) {
+                res->end("exiting thread 2");
+                running=0;
+            }).listen(3000, [](auto *token) {
+                if (token) {
+                    std::cout << "Thread " << std::this_thread::get_id() << " listening on port " << 3000 << std::endl;
+                } else {
+                    std::cout << "Thread " << std::this_thread::get_id() << " failed to listen on port 3000" << std::endl;
+                }
+            }).run();
+
+        });
+    });
+
+    std::for_each(threads.begin(), threads.end(), [](std::thread *t) {
+        t->join();
+    });
+    t2.join();
+}

--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -71,6 +71,7 @@ private:
         /* Also remove onWritable so that we do not emit when draining behind the scenes. */
         httpResponseData->onWritable = nullptr;
 
+
         /* We are done with this request */
         httpResponseData->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
     }
@@ -164,6 +165,16 @@ private:
     }
 
 public:
+
+    // This is the pointer to whatever data is being processed by some other thread for whatever reason
+
+    AsyncProcData* getProcData(){
+        return this->getHttpResponseData()->asyncProcData;
+    }
+
+    void setProcData(AsyncProcData* dptr){
+        this->getHttpResponseData()->asyncProcData = dptr;
+    }
     /* Immediately terminate this Http response */
     using Super::close;
 

--- a/src/HttpResponseData.h
+++ b/src/HttpResponseData.h
@@ -24,8 +24,17 @@
 #include "AsyncSocketData.h"
 
 #include "f2/function2.hpp"
+#include <atomic>
 
 namespace uWS {
+
+struct AsyncProcData{
+    std::string out;
+    // The mutex for proc data, lock with adhoc thead until the request's thread can handle it.
+    std::mutex procDataMutex;
+    std::atomic<bool> asyncProcStarted;
+    std::string asyncInput;
+};
 
 template <bool SSL>
 struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
@@ -50,6 +59,9 @@ private:
 
     /* Current state (content-length sent, status sent, write called, etc */
     int state = 0;
+
+    AsyncProcData* asyncProcData = nullptr;
+
 };
 
 }


### PR DESCRIPTION
I wanted to add an example for batch processing, the problem is that in order to do it kinda-sorta-nicely I added two methods on the HttpResponse struct, a variable to the HttpResponseData struct and added a struct called AsyncProcData to the uWS namespace.  They don't belong there, I know.  I was hoping for suggestions on how I can refactor it so there is a simpler example for async processing than the AsyncFileStreamer.h.  I'm not the best programmer so it took me a couple of days to understand everything and code this up.

Thanks for creating such a great library.  This thing is sick.