### PR TITLE
Fix example build error

### DIFF
--- a/examples/BroadcastingEchoServer.cpp
+++ b/examples/BroadcastingEchoServer.cpp
@@ -14,6 +14,7 @@ int main() {
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024 * 1024,
         .idleTimeout = 10,
+        .maxBackpressure = 1 * 1024 * 1204,
         /* Handlers */
         .open = [](auto *ws, auto *req) {
             /* Let's make every connection subscribe to the "broadcast" topic */

--- a/examples/EchoServer.cpp
+++ b/examples/EchoServer.cpp
@@ -11,7 +11,7 @@ int main() {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024,
-	    .idleTimeout = 10,
+        .idleTimeout = 10,
         .maxBackpressure = 1 * 1024 * 1204,
         /* Handlers */
         .open = [](auto *ws, auto *req) {

--- a/examples/EchoServer.cpp
+++ b/examples/EchoServer.cpp
@@ -11,7 +11,8 @@ int main() {
         /* Settings */
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024,
-	.idleTimeout = 10,
+	    .idleTimeout = 10,
+        .maxBackpressure = 1 * 1024 * 1204,
         /* Handlers */
         .open = [](auto *ws, auto *req) {
 

--- a/examples/EchoServerThreaded.cpp
+++ b/examples/EchoServerThreaded.cpp
@@ -20,6 +20,7 @@ int main() {
                 .compression = uWS::SHARED_COMPRESSOR,
                 .maxPayloadLength = 16 * 1024,
                 .idleTimeout = 10,
+                .maxBackpressure = 1 * 1024 * 1204,
                 /* Handlers */
                 .open = [](auto *ws, auto *req) {
 


### PR DESCRIPTION
This PR fixes problems building examples apps (gcc-8.3).
![image](https://user-images.githubusercontent.com/998319/66968091-21859100-f08c-11e9-88f3-6faa1e5b9038.png)

```
 error: no matching function for call to 'uWS::TemplatedApp<false>::ws<main()::PerSocketData>(const char [3], <brace-enclosed initializer list>)'
     }).listen(9001, [](auto *token) {
      ^
```
