### PR TITLE
Type casting fix

### DIFF
--- a/src/TopicTreeDraft.h
+++ b/src/TopicTreeDraft.h
@@ -345,7 +345,7 @@ public:
                     if ((it[i] != end[i]) && (*it[i] == min)) {
 
                         /* Mark this intersection */
-                        intersection |= (1 << i);
+                        intersection |= ((uint64_t)1 << i);
                         perSubscriberIntersectingTopicMessages[numPerSubscriberIntersectingTopicMessages++] = &triggeredTopics[i]->messages;
 
                         it[i]++;


### PR DESCRIPTION
If we want to utilizate  uint64 type of ```intersection``` variable. We should convert 1 to 64 bit value.
Otherwise, if value of ```i``` exceeds 32 we can get an unobvious value.