### PR TITLE
Remove unused capture `httpContext` in `onHttp` lambda.

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -183,7 +183,7 @@ public:
         webSocketContext->getExt()->maxBackpressure = behavior.maxBackpressure;
         webSocketContext->getExt()->compression = behavior.compression;
 
-        httpContext->onHttp("get", pattern, [webSocketContext, httpContext = this->httpContext, behavior = std::move(behavior)](auto *res, auto *req) mutable {
+        httpContext->onHttp("get", pattern, [webSocketContext, behavior = std::move(behavior)](auto *res, auto *req) mutable {
 
             /* If we have this header set, it's a websocket */
             std::string_view secWebSocketKey = req->getHeader("sec-websocket-key");


### PR DESCRIPTION
Remove unused capture `httpContext` in `onHttp` lambda.