### PR TITLE
1. Use the size_t to instead of the int to avoid the GCC warning.

### DIFF
--- a/src/HttpRouter.h
+++ b/src/HttpRouter.h
@@ -58,9 +58,9 @@ private:
     /* The matching tree */
     struct Node {
         std::string name;
-        std::vector<std::unique_ptr<Node>> children;
-        std::vector<uint32_t> handlers;
-        bool isHighPriority;
+        std::vector<std::unique_ptr<Node>> children = {};
+        std::vector<uint32_t> handlers = {};
+        bool isHighPriority = 0;
     } root = {"rootNode"};
 
     /* Advance from parent to child, adding child if necessary */

--- a/src/QueryParser.h
+++ b/src/QueryParser.h
@@ -59,7 +59,7 @@ namespace uWS {
                         int out = 0;
 
                         /* Walk over all chars until end or null char, decoding in place */
-                        for (int i = 0; in[i] && i < statementValue.length(); i++) {
+                        for (size_t i = 0; in[i] && i < statementValue.length(); i++) {
                                 /* Only bother with '%' */
                                 if (in[i] == '%') {
                                     /* Do we have enough data for two bytes hex? */
@@ -96,7 +96,7 @@ namespace uWS {
                         }
 
                         /* If decoded string is shorter than original, put null char to stop next read */
-                        if (out < statementValue.length()) {
+                        if ((size_t)out < statementValue.length()) {
                             in[out] = 0;
                         }
 

--- a/src/WebSocketProtocol.h
+++ b/src/WebSocketProtocol.h
@@ -153,9 +153,9 @@ static bool isValidUtf8(unsigned char *s, size_t length)
 }
 
 struct CloseFrame {
-    uint16_t code;
-    char *message;
-    size_t length;
+    uint16_t code = 0;
+    char *message = nullptr;
+    size_t length = 0;
 };
 
 static inline CloseFrame parseClosePayload(char *src, size_t length) {


### PR DESCRIPTION
2. Initialize the struct Node and struct CloseFrame to avoid the GCC warning.
Since in my project, I treat the warning as error so can't get it compiled.