### PR TITLE
Makes benchmarks compile with clang

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,7 @@
 default:
-	clang -flto -O3 -DLIBUS_USE_OPENSSL -I../uSockets/src ../uSockets/src/*.c ../uSockets/src/eventing/*.c ../uSockets/src/crypto/*.c broadcast_test.c -o broadcast_test -lssl -lcrypto
-	clang -flto -O3 -DLIBUS_USE_OPENSSL -I../uSockets/src ../uSockets/src/*.c ../uSockets/src/eventing/*.c ../uSockets/src/crypto/*.c load_test.c -o load_test -lssl -lcrypto
-	clang -flto -O3 -DLIBUS_USE_OPENSSL -I../uSockets/src ../uSockets/src/*.c ../uSockets/src/eventing/*.c ../uSockets/src/crypto/*.c scale_test.c -o scale_test -lssl -lcrypto
+	clang -flto -O3 -DLIBUS_USE_OPENSSL -I../uSockets/src ../uSockets/src/*.c ../uSockets/src/eventing/*.c ../uSockets/src/crypto/*.c broadcast_test.c load_test.c scale_test.c -c
+	clang++ -flto -O3 -DLIBUS_USE_OPENSSL -I../uSockets/src ../uSockets/src/crypto/*.cpp -c -std=c++20
+	clang++ -flto -O3 -DLIBUS_USE_OPENSSL `ls *.o | grep -Ev "load_test|scale_test"` -lssl -lcrypto -o broadcast_test
+	clang++ -flto -O3 -DLIBUS_USE_OPENSSL `ls *.o | grep -Ev "broadcast_test|scale_test"` -lssl -lcrypto -o load_test
+	clang++ -flto -O3 -DLIBUS_USE_OPENSSL `ls *.o | grep -Ev "broadcast_test|load_test"` -lssl -lcrypto -o scale_test
+


### PR DESCRIPTION
Hi Alex,

Benchmarks didn't compile because a cpp file sni_tree.cpp was added, and the previous makefile only included .c files, leading to missing symbols at the linking stage. As LTO generated object files are incompatible between GCC and LLVM, it is useful to regenerate all object files in uSockets. This pull request does so. 

As on Linux GCC is the default, but the fuzzing requires libfuzzer from LLVM, using LLVM is actually the only way to reach the benchmarks target in the root Makefile, I found that using `WITH_OPENSSL=1 CC=clang CXX=clang++ make` is the only way to compile all targets, as GCC doesn't support fuzzing. Nontheless, if people have compiled using plain make and thus using the default GCC on Linux, the makefile in the benchmarks directory still works as it regenerated the object files in that same directory, preventing some surprises, as GCC and LLVM produced objects are generally ABI compatible.

Let me know if something is wrong with the commit, I can make improvements if needed.