### PR TITLE
Fix potential memory leak in WebSocket

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -100,10 +100,8 @@ public:
         if (requiresWrite) {
             auto[written, failed] = Super::write(sendBuffer, (int) messageFrameSize);
 
-            /* For now, we are slow here */
-            free(sendBuffer);
-
             if (failed) {
+                free(sendBuffer);
                 /* Return false for failure, skipping to reset the timeout below */
                 return false;
             }
@@ -113,9 +111,12 @@ public:
         if (automaticallyCorked) {
             auto [written, failed] = Super::uncork();
             if (failed) {
+                free(sendBuffer);
                 return false;
             }
         }
+
+        free(sendBuffer);
 
         /* Every successful send resets the timeout */
         Super::timeout(webSocketContextData->idleTimeout);


### PR DESCRIPTION
The `sendBuffer` created using `malloc` in `AsyncSocket.h` is not freed in all the paths returning from this function. This potential memory leak was identified by a clang-tidy tool check.