### PR TITLE
add logging interface

### DIFF
--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -155,13 +155,17 @@ private:
                 httpContextData->router.getUserData() = {(HttpResponse<SSL> *) s, httpRequest};
                 if (!httpContextData->router.route(httpRequest->getMethod(), httpRequest->getUrl())) {
                     /* We have to force close this socket as we have no handler for it */
+                    #if UWS_LOG_LEVEL <= 1
                     log("No handler for route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 1);
+                    #endif
                     us_socket_close(SSL, (us_socket_t *) s, 0, nullptr);
                     return nullptr;
                 }
+                #if UWS_LOG_LEVEL <= 3
                 else {
                     log("Successfully handled route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 3);
                 }
+                #endif
 
                 /* First of all we need to check if this socket was deleted due to upgrade */
                 if (httpContextData->upgradedWebSocket) {

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -25,9 +25,9 @@
 #include "HttpResponseData.h"
 #include "AsyncSocket.h"
 #include "WebSocketData.h"
+#include "Log.h"
 
 #include <string_view>
-#include <iostream>
 #include "f2/function2.hpp"
 
 namespace uWS {
@@ -155,8 +155,12 @@ private:
                 httpContextData->router.getUserData() = {(HttpResponse<SSL> *) s, httpRequest};
                 if (!httpContextData->router.route(httpRequest->getMethod(), httpRequest->getUrl())) {
                     /* We have to force close this socket as we have no handler for it */
+                    log("No handler for route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 1);
                     us_socket_close(SSL, (us_socket_t *) s, 0, nullptr);
                     return nullptr;
+                }
+                else {
+                    log("Successfully handled route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 3);
                 }
 
                 /* First of all we need to check if this socket was deleted due to upgrade */
@@ -177,8 +181,7 @@ private:
 
                 /* Returning from a request handler without responding or attaching an onAborted handler is ill-use */
                 if (!((HttpResponse<SSL> *) s)->hasResponded() && !httpResponseData->onAborted) {
-                    /* Throw exception here? */
-                    std::cerr << "Error: Returning from a request handler without responding or attaching an abort handler is forbidden!" << std::endl;
+                    log("Error: Returning from a request handler without responding or attaching an abort handler is forbidden!", 0);
                     std::terminate();
                 }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -144,6 +144,7 @@ private:
 
                 /* Are we not ready for another request yet? Terminate the connection. */
                 if (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) {
+                    UWS_LOG_REQUEST(3, "terminating connection (HTTP_RESPONSE_PENDING)");
                     us_socket_close(SSL, (us_socket_t *) s, 0, nullptr);
                     return nullptr;
                 }
@@ -166,16 +167,19 @@ private:
                 /* First of all we need to check if this socket was deleted due to upgrade */
                 if (httpContextData->upgradedWebSocket) {
                     /* We differ between closed and upgraded below */
+                    UWS_LOG_REQUEST(3, "socket was deleted due to upgrade");
                     return nullptr;
                 }
 
                 /* Was the socket closed? */
                 if (us_socket_is_closed(SSL, (struct us_socket_t *) s)) {
+                    UWS_LOG_REQUEST(3, "socket was closed");
                     return nullptr;
                 }
 
                 /* We absolutely have to terminate parsing if shutdown */
                 if (us_socket_is_shut_down(SSL, (us_socket_t *) s)) {
+                    UWS_LOG_REQUEST(3, "socket was shutdown");
                     return nullptr;
                 }
 
@@ -211,11 +215,13 @@ private:
 
                     /* Was the socket closed? */
                     if (us_socket_is_closed(SSL, (struct us_socket_t *) user)) {
+                        UWS_LOG_REQUEST(3, "socket was closed");
                         return nullptr;
                     }
 
                     /* We absolutely have to terminate parsing if shutdown */
                     if (us_socket_is_shut_down(SSL, (us_socket_t *) user)) {
+                        UWS_LOG_REQUEST(3, "socket was shutdown");
                         return nullptr;
                     }
 
@@ -343,6 +349,7 @@ public:
         httpContext = (HttpContext *) us_create_socket_context(SSL, (us_loop_t *) loop, sizeof(HttpContextData<SSL>), options);
 
         if (!httpContext) {
+            UWS_LOG_REQUEST(0, "Error: Failed to create a httpContext");
             return nullptr;
         }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -155,17 +155,13 @@ private:
                 httpContextData->router.getUserData() = {(HttpResponse<SSL> *) s, httpRequest};
                 if (!httpContextData->router.route(httpRequest->getMethod(), httpRequest->getUrl())) {
                     /* We have to force close this socket as we have no handler for it */
-                    #if UWS_LOG_LEVEL <= 1
-                    log("No handler for route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 1);
-                    #endif
+                    UWS_LOG_REQUEST("No handler for route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 1);
                     us_socket_close(SSL, (us_socket_t *) s, 0, nullptr);
                     return nullptr;
                 }
-                #if UWS_LOG_LEVEL <= 3
                 else {
-                    log("Successfully handled route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 3);
+                    UWS_LOG_REQUEST("Successfully handled route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 3);
                 }
-                #endif
 
                 /* First of all we need to check if this socket was deleted due to upgrade */
                 if (httpContextData->upgradedWebSocket) {
@@ -185,7 +181,7 @@ private:
 
                 /* Returning from a request handler without responding or attaching an onAborted handler is ill-use */
                 if (!((HttpResponse<SSL> *) s)->hasResponded() && !httpResponseData->onAborted) {
-                    log("Error: Returning from a request handler without responding or attaching an abort handler is forbidden!", 0);
+                    UWS_LOG_REQUEST("Error: Returning from a request handler without responding or attaching an abort handler is forbidden!", 0);
                     std::terminate();
                 }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -155,12 +155,12 @@ private:
                 httpContextData->router.getUserData() = {(HttpResponse<SSL> *) s, httpRequest};
                 if (!httpContextData->router.route(httpRequest->getMethod(), httpRequest->getUrl())) {
                     /* We have to force close this socket as we have no handler for it */
-                    UWS_LOG_REQUEST("No handler for route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 1);
+                    UWS_LOG_REQUEST(1, "No handler for route ", httpRequest->getMethod(), " ", httpRequest->getUrl());
                     us_socket_close(SSL, (us_socket_t *) s, 0, nullptr);
                     return nullptr;
                 }
                 else {
-                    UWS_LOG_REQUEST("Successfully handled route " + std::string(httpRequest->getMethod()) + " " + std::string(httpRequest->getUrl()), 3);
+                    UWS_LOG_REQUEST(3, "Successfully handled route ", httpRequest->getMethod(), " ", httpRequest->getUrl());
                 }
 
                 /* First of all we need to check if this socket was deleted due to upgrade */
@@ -181,7 +181,7 @@ private:
 
                 /* Returning from a request handler without responding or attaching an onAborted handler is ill-use */
                 if (!((HttpResponse<SSL> *) s)->hasResponded() && !httpResponseData->onAborted) {
-                    UWS_LOG_REQUEST("Error: Returning from a request handler without responding or attaching an abort handler is forbidden!", 0);
+                    UWS_LOG_REQUEST(0, "Error: Returning from a request handler without responding or attaching an abort handler is forbidden!");
                     std::terminate();
                 }
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -34,7 +34,7 @@ class LogBuffer
         LogBuffer& operator<< (std::string_view sv) {
             const size_t bytesFree = buf.size() - cursor;
             if(sv.size() > bytesFree)
-                throw std::length_error("log message too long");
+                return *this;
             memcpy(&buf[cursor], sv.data(), sv.size());
             cursor += sv.size();
             return *this;

--- a/src/Log.h
+++ b/src/Log.h
@@ -1,0 +1,28 @@
+#ifndef UWS_LOG_H
+#define UWS_LOG_H
+#include <functional>
+#include <iostream>
+#include <string>
+
+namespace uWS {
+
+/*!
+ * \brief Log a message. The user of this lib is free to override this function object with a custom logger.
+ * \param [in] message The message to be logged.
+ * \param [in] logLevel The severity of the message. 0 is error, 1 is warning, 2 is info. With each increment the severity decrements.
+ */
+typedef std::function<void(const std::string& message, int logLevel)> LogFunction;
+
+inline LogFunction log = [](const std::string& message, int logLevel) -> void {
+    if(logLevel <= 1) {
+        std::cerr << message << std::endl;
+    }
+    else {
+        std::cout << message << std::endl;
+    }
+};
+
+}  // namespace uWS
+
+#endif  // UWS_LOG_H
+

--- a/src/Log.h
+++ b/src/Log.h
@@ -12,7 +12,7 @@ namespace uWS {
 /*!
  * \brief Log a message. The user of this lib is free to override this function object with a custom logger.
  * \param [in] message The message to be logged.
- * \param [in] logLevel The severity of the message. 0 is error, 1 is warning, 2 is info. With each increment the severity decrements.
+ * \param [in] logLevel The severity of the message. 0 is error, 1 is warning, 2 is info, 3 is debug. With each increment the severity decrements.
  */
 typedef std::function<void(std::string_view message, int logLevel)> LogFunction;
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -1,8 +1,9 @@
 #ifndef UWS_LOG_H
 #define UWS_LOG_H
+#include <array>
 #include <functional>
 #include <iostream>
-#include <string>
+#include <string_view>
 
 #define UWS_LOG_LEVEL 0  // override this to get more verbose logging
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <string>
 
+#define UWS_LOG_LEVEL 0  // override this to get more verbose logging
+
 namespace uWS {
 
 /*!

--- a/src/Log.h
+++ b/src/Log.h
@@ -24,6 +24,12 @@ inline LogFunction log = [](const std::string& message, int logLevel) -> void {
     }
 };
 
+#define UWS_LOG_REQUEST(msg, loglevel) { \
+    if constexpr(loglevel <= UWS_LOG_LEVEL) { \
+        log(msg, loglevel); \
+    } \
+}
+
 }  // namespace uWS
 
 #endif  // UWS_LOG_H


### PR DESCRIPTION
Currently, there is just a single logging line in uWebSockets which writes to `std::cerr`. I added two more such lines. More importantly, I introduced a function object `uWS::log` that can be overridden by users to accord with their logging library. For example, [spdlog](https://github.com/gabime/spdlog) users might want to write something like this:
```c++
uWS::log = [](const std::string& message, const int logLevel) -> void {
    switch(logLevel) {
        case 0:
            SPDLOG_ERROR(message);
            break;
        case 1:
            SPDLOG_WARN(message);
            break;
        case 2:
            SPDLOG_INFO(message);
            break;
        case 3:
            SPDLOG_DEBUG(message);
    }
};
```

Nothing changes for users who do not configure anything.