### PR TITLE
Fixes compilation error due to a missing 'struct' keyword

### DIFF
--- a/src/AsyncSocket.h
+++ b/src/AsyncSocket.h
@@ -65,7 +65,7 @@ protected:
     }
 
     /* Immediately close socket */
-    us_socket_t *close() {
+    struct us_socket_t *close() {
         return us_socket_close(SSL, (us_socket_t *) this, 0, nullptr);
     }
 

--- a/src/WebSocketContextData.h
+++ b/src/WebSocketContextData.h
@@ -147,12 +147,12 @@ public:
         return 0;
     }) {
         /* We empty for both pre and post just to make sure */
-        Loop::get()->addPostHandler(this, [this](Loop */*loop*/) {
+        Loop::get()->addPostHandler(this, [this](Loop * /*loop*/) {
             /* Commit pub/sub batches every loop iteration */
             topicTree.drain();
         });
 
-        Loop::get()->addPreHandler(this, [this](Loop */*loop*/) {
+        Loop::get()->addPreHandler(this, [this](Loop * /*loop*/) {
             /* Commit pub/sub batches every loop iteration */
             topicTree.drain();
         });


### PR DESCRIPTION
us_socket_t type is normally preceded by 'struct' keyword, this is missing in one spot causing compile error. 