### PR TITLE
Shorter socket-timeouts after WebSocket::end() (#1245)

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -167,10 +167,14 @@ public:
             }
         }
 
-        /* Emit close event */
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = (WebSocketContextData<SSL, USERDATA> *) us_socket_context_ext(SSL,
             (us_socket_context_t *) us_socket_context(SSL, (us_socket_t *) this)
         );
+
+        /* Set shorter timeout (use ping-timeout) to avoid long hanging sockets after end() on broken connections */
+        Super::timeout(webSocketContextData->idleTimeoutComponents.second);
+
+        /* Emit close event */
         if (webSocketContextData->closeHandler) {
             webSocketContextData->closeHandler(this, code, message);
         }

--- a/src/WebSocketContext.h
+++ b/src/WebSocketContext.h
@@ -364,7 +364,7 @@ private:
             auto *webSocketData = (WebSocketData *)(us_socket_ext(SSL, s));
             auto *webSocketContextData = (WebSocketContextData<SSL, USERDATA> *) us_socket_context_ext(SSL, us_socket_context(SSL, (us_socket_t *) s));
 
-            if (webSocketContextData->sendPingsAutomatically && !webSocketData->hasTimedOut) {
+            if (webSocketContextData->sendPingsAutomatically && !webSocketData->isShuttingDown && !webSocketData->hasTimedOut) {
                 webSocketData->hasTimedOut = true;
                 us_socket_timeout(SSL, s, webSocketContextData->idleTimeoutComponents.second);
                 /* Send ping without being corked */

--- a/src/WebSocketContextData.h
+++ b/src/WebSocketContextData.h
@@ -85,13 +85,9 @@ public:
         while ((int) idleTimeout - margin * 2 >= margin * 2 && margin < 16) {
             margin = (unsigned short) (margin << 1);
         }
-        /* We should have no margin if not using sendPingsAutomatically */
-        if (!sendPingsAutomatically) {
-            margin = 0;
-        }
         idleTimeoutComponents = {
-            idleTimeout - margin,
-            margin
+            idleTimeout - (sendPingsAutomatically ? margin : 0), /* reduce normal idleTimeout if it is extended by ping-timeout */
+            margin /* ping-timeout - also used for end() timeout */
         };
     }
 


### PR DESCRIPTION
Just using the ping-timeout as end-timeout for now.

Setting the timeout after sending the close-message should also overwrite the timeout set by `send` if `resetIdleTimeoutOnSend` is active.

Also check `webSocketData->isShuttingDown` in `on_timeout()` ... this seems to be a small bug in any case (a ping may have been sent on a socket on timeout after being `shutdown()`).