### PR TITLE
Fix 4Gb limit streamed HTTP on Raspberry Pi 32bit

### DIFF
--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -93,7 +93,7 @@ private:
 
     /* Returns true on success, indicating that it might be feasible to write more data.
      * Will start timeout if stream reaches totalSize or write failure. */
-    bool internalEnd(std::string_view data, size_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
+    bool internalEnd(std::string_view data, uintmax_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
@@ -375,7 +375,7 @@ public:
 
     /* Try and end the response. Returns [true, true] on success.
      * Starts a timeout in some cases. Returns [ok, hasResponded] */
-    std::pair<bool, bool> tryEnd(std::string_view data, size_t totalSize = 0) {
+    std::pair<bool, bool> tryEnd(std::string_view data, uintmax_t totalSize = 0) {
         return {internalEnd(data, totalSize, true), hasResponded()};
     }
 
@@ -413,7 +413,7 @@ public:
     }
 
     /* Get the current byte write offset for this Http response */
-    size_t getWriteOffset() {
+    uintmax_t getWriteOffset() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         return httpResponseData->offset;
@@ -448,7 +448,7 @@ public:
     }
 
     /* Attach handler for writable HTTP response */
-    HttpResponse *onWritable(MoveOnlyFunction<bool(size_t)> &&handler) {
+    HttpResponse *onWritable(MoveOnlyFunction<bool(uintmax_t)> &&handler) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = std::move(handler);

--- a/src/HttpResponseData.h
+++ b/src/HttpResponseData.h
@@ -43,11 +43,11 @@ private:
     };
 
     /* Per socket event handlers */
-    MoveOnlyFunction<bool(size_t)> onWritable;
+    MoveOnlyFunction<bool(uintmax_t)> onWritable;
     MoveOnlyFunction<void()> onAborted;
     MoveOnlyFunction<void(std::string_view, bool)> inStream; // onData
     /* Outgoing offset */
-    size_t offset = 0;
+    uintmax_t offset = 0;
 
     /* Current state (content-length sent, status sent, write called, etc */
     int state = 0;


### PR DESCRIPTION
Commits f2198ccfac140798ee066c5a3c5235b396473205 and 4fcfe49bcce574c0aca7ab6409f81a725bf8f88c
are fixed 2Gb limit, but introduced 4Gb limit on Rasperry Pi 32 bit.
This is because the max value of type `size_t` is `4294967295` on this
system.
Furthermore, the Standard Library use `std::uintmax_t` as a type
of value returned by `std::filesystem::file_size`.