### PR TITLE
ws.publish() - fix #1269

### DIFF
--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -91,7 +91,7 @@ struct Intersection {
         unsigned int examinedHoles = 0;
 
         /* This is a slow path of sorts, most subscribers will be observers, not active senders */
-        if (senderForMessages.size()) {
+        if (!senderForMessages.empty()) {
         for (; examinedHoles < holes.size(); examinedHoles++) {
             std::pair<size_t, size_t> toEmit = {};
             std::pair<size_t, size_t> toIgnore = {};

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -89,6 +89,8 @@ struct Intersection {
         /* Holes are global to the entire topic tree, so we are not guaranteed to find
          * holes in this intersection - they are sorted, though */
         unsigned int examinedHoles = 0;
+        unsigned int latestMatch = 0;
+        unsigned int end = senderForMessages.size();
 
         /* This is a slow path of sorts, most subscribers will be observers, not active senders */
         if (!senderForMessages.empty()) {
@@ -99,10 +101,11 @@ struct Intersection {
             /* This linear search is most probably very small - it could be made log2 if every hole
              * knows about its previous accumulated length, which is easy to set up. However this
              * log2 search will most likely never be a warranted perf. gain */
-            for (unsigned int id : senderForMessages) {
-                if (holes[examinedHoles].messageId == id) {
+            for (unsigned int i = latestMatch; i < end; i++) {
+                if (holes[examinedHoles].messageId == senderForMessages[i]) {
                     toIgnore.first += holes[examinedHoles].lengths.first;
                     toIgnore.second += holes[examinedHoles].lengths.second;
+                    latestMatch = i;
                     break;
                 }
             }

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -95,9 +95,8 @@ struct Intersection {
             /* Iterate each message looking for any to skip */
             for (auto &message : holes) {
 
-                bool skipMessage = false;
-
                 /* If this message was sent by this subscriber skip it */
+                bool skipMessage = false;
                 for (unsigned int i = lastMatch; i < senderForMessages.size(); i++) {
                     if (message.messageId == senderForMessages[i]) {
                         skipMessage = true;

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -121,7 +121,7 @@ struct Intersection {
                         emitted.second += toEmit.second;
                         toEmit = {};
                     }
-                    /* This message is now accounted for, mark as emmited */
+                    /* This message is now accounted for, mark as emitted */
                     emitted.first += message.lengths.first;
                     emitted.second += message.lengths.second;
                 }

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -86,13 +86,12 @@ struct Intersection {
         /* How far we already emitted of the two dataChannels */
         std::pair<size_t, size_t> emitted = {};
 
-        /* Holes are global to the entire topic tree, so we are not guaranteed to find
-         * holes in this intersection - they are sorted, though */
-        unsigned int latestMatch = 0;
-        unsigned int end = senderForMessages.size();
-
         /* This is a slow path of sorts, most subscribers will be observers, not active senders */
         if (!senderForMessages.empty()) {
+
+            unsigned int latestMatch = 0;
+            unsigned int end = senderForMessages.size();
+
             for (auto &message : holes) {
                 std::pair<size_t, size_t> toEmit = {};
                 std::pair<size_t, size_t> toIgnore = {};

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -101,7 +101,7 @@ struct Intersection {
                     if (message.messageId == senderForMessages[i]) {
                         toIgnore.first += message.lengths.first;
                         toIgnore.second += message.lengths.second;
-                        latestMatch = i;
+                        latestMatch = ++i;
                         break;
                     }
                 }

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -90,17 +90,21 @@ struct Intersection {
         if (!senderForMessages.empty()) {
 
             std::pair<size_t, size_t> toEmit = {};
-            unsigned int lastMatch = 0;
+            unsigned int startAt = 0;
 
             /* Iterate each message looking for any to skip */
             for (auto &message : holes) {
 
                 /* If this message was sent by this subscriber skip it */
                 bool skipMessage = false;
-                for (unsigned int i = lastMatch; i < senderForMessages.size(); i++) {
+                for (unsigned int i = startAt; i < senderForMessages.size(); i++) {
+                    if (senderForMessages[i] > message.messageId) {
+                        startAt = i;
+                        break;
+                    }
                     if (message.messageId == senderForMessages[i]) {
                         skipMessage = true;
-                        lastMatch = ++i;
+                        startAt = ++i;
                         break;
                     }
                 }


### PR DESCRIPTION
fix #1269

updated file: [TopicTree.h](https://github.com/uNetworking/uWebSockets/blob/6340368194881f6ab164b15619349e8856a70eca/src/TopicTree.h#L90-L133)

```c++
if (!senderForMessages.empty()) {

    std::pair<size_t, size_t> toEmit = {};
    unsigned int startAt = 0;

    /* Iterate each message looking for any to skip */
    for (auto &message : holes) {

        /* If this message was sent by this subscriber skip it */
        bool skipMessage = false;
        for (unsigned int i = startAt; i < senderForMessages.size(); i++) {
            if (senderForMessages[i] > message.messageId) {
                startAt = i;
                break;
            }
            if (message.messageId == senderForMessages[i]) {
                skipMessage = true;
                startAt = ++i;
                break;
            }
        }

        /* Collect messages until a skip, then emit messages */
        if (!skipMessage) {
            toEmit.first += message.lengths.first;
            toEmit.second += message.lengths.second;
        } else {
            if (toEmit.first || toEmit.second) {
                std::pair<std::string_view, std::string_view> cutDataChannels = {
                    std::string_view(dataChannels.first.data() + emitted.first, toEmit.first),
                    std::string_view(dataChannels.second.data() + emitted.second, toEmit.second),
                };
                /* Only need to test the first data channel for "FIN" */
                cb(cutDataChannels, emitted.first + toEmit.first + message.lengths.first == dataChannels.first.length());
                emitted.first += toEmit.first;
                emitted.second += toEmit.second;
                toEmit = {};
            }
            /* This message is now accounted for, mark as emitted */
            emitted.first += message.lengths.first;
            emitted.second += message.lengths.second;
        }
    }
}
```