### PR TITLE
ws.publish() - fix #1269

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -278,7 +278,13 @@ public:
         }
 
         /* Publish as sender, does not receive its own messages even if subscribed to relevant topics */
-        bool success = webSocketContextData->publish(topic, message, opCode, compress, webSocketData->subscriber);
+        /* Don't pass subscriber argument if not subscribed to topic, not needed and interferes with Publish #1269 */
+        bool success;
+        if (isSubscribed(topic)) {
+            success = webSocketContextData->publish(topic, message, opCode, compress, webSocketData->subscriber);
+        } else {
+            success = webSocketContextData->publish(topic, message, opCode, compress);
+        }
 
         /* Loop over all websocket contexts for this App */
         if (success) {


### PR DESCRIPTION
This is an easy fix, just don't pass subscriber to the internal publish function if not subscribed to that topic, this leaves the message ID out of the sender skip message list for a topic it's not subscribed to and prevents the incorrect behavior, because Publish is designed to only have skip message IDs that are included in that topic which allows the algorithm to be more efficient, message ID's not in that topic break the algorithm and cause all remaining messages to be sent 

fix #1269