### PR TITLE
filter message ids fix #1269

### DIFF
--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -90,8 +90,16 @@ struct Intersection {
          * holes in this intersection - they are sorted, though */
         unsigned int examinedHoles = 0;
 
+        /* Get the intersection of senderForMessages and Message ID's to filter out Message ID's that don't apply #1269 */
+        std::vector<unsigned int> skipMessageIDs;
+        if (!senderForMessages.empty()) {
+            std::vector<unsigned int> messageIDs;
+            std::transform(holes.begin(), holes.end(), std::back_inserter(messageIDs), [](auto hole){ return hole.messageId; });
+            std::set_intersection(senderForMessages.begin(), senderForMessages.end(), messageIDs.begin(), messageIDs.end(), back_inserter(skipMessageIDs));
+        }
+
         /* This is a slow path of sorts, most subscribers will be observers, not active senders */
-        for (unsigned int id : senderForMessages) {
+        for (unsigned int id : skipMessageIDs) {
             std::pair<size_t, size_t> toEmit = {};
             std::pair<size_t, size_t> toIgnore = {};
 

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -87,7 +87,7 @@ struct Intersection {
          * holes in this intersection - they are sorted, though */
         unsigned int examinedMessages = 0;
 
-        /* Get the intersection of senderMessageIDs and MessageID's to filter out skipMessageIDs's that don't apply #1269 */
+        /* Get the intersection of senderMessageIDs and messageIDs to filter out skipMessageIDs that don't apply #1269 */
         std::vector<unsigned int> skipMessageIDs;
         if (!senderMessageIDs.empty()) {
             set_intersection(senderMessageIDs.begin(), senderMessageIDs.end(), messageIDs.begin(), messageIDs.end(), back_inserter(skipMessageIDs));

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -79,7 +79,7 @@ struct Intersection {
     std::vector<std::pair<size_t, size_t>> messageLengths;
     std::vector<unsigned int> messageIDs;
 
-    void forSubscriber(std::vector<unsigned int> &senderForMessages, std::function<void(std::pair<std::string_view, std::string_view>, bool)> cb) {
+    void forSubscriber(std::vector<unsigned int> &senderMessageIDs, std::function<void(std::pair<std::string_view, std::string_view>, bool)> cb) {
         /* How far we already emitted of the two dataChannels */
         std::pair<size_t, size_t> emitted = {};
 
@@ -87,10 +87,10 @@ struct Intersection {
          * holes in this intersection - they are sorted, though */
         unsigned int examinedMessages = 0;
 
-        /* Get the intersection of senderForMessages and MessageID's to filter out skipMessageIDs's that don't apply #1269 */
+        /* Get the intersection of senderMessageIDs and MessageID's to filter out skipMessageIDs's that don't apply #1269 */
         std::vector<unsigned int> skipMessageIDs;
-        if (!senderForMessages.empty()) {
-            set_intersection(senderForMessages.begin(), senderForMessages.end(), messageIDs.begin(), messageIDs.end(), back_inserter(skipMessageIDs));
+        if (!senderMessageIDs.empty()) {
+            set_intersection(senderMessageIDs.begin(), senderMessageIDs.end(), messageIDs.begin(), messageIDs.end(), back_inserter(skipMessageIDs));
         }
 
         /* This is a slow path of sorts, most subscribers will be observers, not active senders */


### PR DESCRIPTION
senderForMessages and Holes are both sorted message id vectors so you can efficiently get the intersection with `std::set_intersection` use that to filter out irrelevant message ids and fix issue