### PR TITLE
Fix for case - when server subscribed to to topic and connection is closed segmentation fault will happen

### DIFF
--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -214,8 +214,11 @@ private:
             }
 
             /* Free various memory for the node */
+            topic->fullName.clear();
             delete [] topic->name;
+            topic->name = nullptr;
             delete topic;
+            topic = nullptr;
 
             if (parent == root) {
               break;

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -183,7 +183,7 @@ private:
     Subscriber *min = (Subscriber *) UINTPTR_MAX;
 
     /* Cull or trim unused Topic nodes from leaf to root */
-    void trimTree(Topic *topic) {
+    void trimTree(Topic *&topic) {
         while (!topic->subs.size() && !topic->children.size() && !topic->terminatingWildcardChild && !topic->wildcardChild) {
             Topic *parent = topic->parent;
 
@@ -456,9 +456,9 @@ public:
     }
 
     /* Can be called with nullptr, ignore it then */
-    void unsubscribeAll(Subscriber *subscriber, bool mayFlush = true) {
+    void unsubscribeAll(Subscriber *&subscriber, bool mayFlush = true) {
         if (subscriber) {
-            for (Topic *topic : subscriber->subscriptions) {
+            for (auto& topic : subscriber->subscriptions) {
 
                 /* We do not want to flush when closing a socket, it makes no sense to do so */
 

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -179,6 +179,8 @@ public:
         webSocketContextData->topicTree.unsubscribeAll(webSocketData->subscriber, false);
         delete webSocketData->subscriber;
         webSocketData->subscriber = nullptr;
+        webSocketData->~WebSocketData();
+        webSocketData = nullptr;
     }
 
     /* Corks the response if possible. Leaves already corked socket be. */

--- a/src/WebSocketContext.h
+++ b/src/WebSocketContext.h
@@ -254,9 +254,6 @@ private:
                 webSocketData->subscriber = nullptr;
             }
 
-            /* Destruct in-placed data struct */
-            webSocketData->~WebSocketData();
-
             return s;
         });
 

--- a/src/WebSocketData.h
+++ b/src/WebSocketData.h
@@ -62,10 +62,12 @@ public:
     ~WebSocketData() {
         if (deflationStream) {
             delete deflationStream;
+            deflationStream = nullptr;
         }
 
         if (subscriber) {
             delete subscriber;
+            subscriber = nullptr;
         }
     }
 };


### PR DESCRIPTION
Steps to reproduce:
I have a multi-threaded server where each thread is having it's own websocket ( message loop, ...).
When a connection is happen I am subscribing to a topic.
After connection is closed from client side server is trying to clean the subscribers but a segmentation fault is happening.

I found that the reason for this is that no proper clean up is done after memory is de-allocated.

In file _WebSocketContext.h_ when socket is closed there is a call for 
            **webSocketData->~WebSocketData();**
            
Destructor will delete the allocated memory. 
Then in **Websocket.h**  will be called **end** function which will call  _unsubscribeAll_ . 
In side unsubscribeAll check for if subscriber is nullptr will pass but next invocation for 
**subscriber->subscriptions** will create seg fault because memory was already deleted in destructor. 

Reason for this  seg fault of explicit call of destructor **webSocketData** in init method **WebSocketContext.h**
This call looks like should happen later.

Moved explicit call of destructor to end function in Websocket.h.