### PR TITLE
Fix possibly race condition in Loop.h

### DIFF
--- a/src/Loop.h
+++ b/src/Loop.h
@@ -34,13 +34,13 @@ private:
         loopData->deferMutex.lock();
         int oldDeferQueue = loopData->currentDeferQueue;
         loopData->currentDeferQueue = (loopData->currentDeferQueue + 1) % 2;
-        loopData->deferMutex.unlock();
 
         /* Drain the queue */
         for (auto &x : loopData->deferQueues[oldDeferQueue]) {
             x();
         }
         loopData->deferQueues[oldDeferQueue].clear();
+        loopData->deferMutex.unlock();
     }
 
     static void preCb(us_loop_t *loop) {


### PR DESCRIPTION
Hello, thank you for your library.
I experienced crashes due to segfault and double-free corruption.  
After this patch, I didn't have any more crashes (although I'm still not totally sure I use this patch)
That's why I submit you this pull request in case you think it's relevant and doesn't burden the performance too much.