### PR TITLE
Fixed masking for continuations

### DIFF
--- a/src/WebSocketProtocol.h
+++ b/src/WebSocketProtocol.h
@@ -401,7 +401,7 @@ protected:
             if (isServer) {
                 /* No need to unmask if mask is 0 */
                 uint32_t nullmask = 0;
-                if (!memcmp(wState->mask, &nullmask, sizeof(uint32_t))) {
+                if (memcmp(wState->mask, &nullmask, sizeof(uint32_t))) {
                     if /*constexpr*/ (LIBUS_RECV_BUFFER_LENGTH == length) {
                         unmaskAll(src, wState->mask);
                     } else {


### PR DESCRIPTION
Hi,

it seems like WebSocket-masking is not done for continuations (see diff below).

In fact, I observed for our project that - if a websocket frame is split into several TCP frames - only the first one is demasked. The provided patch should fix that