### PR TITLE
Allow passing custom ciphers via options

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -76,6 +76,7 @@ namespace uWS {
         const char *passphrase = nullptr;
         const char *dh_params_file_name = nullptr;
         const char *ca_file_name = nullptr;
+        const char *ssl_ciphers = nullptr;
         int ssl_prefer_low_memory_usage = 0;
 
         /* Conversion operator used internally */


### PR DESCRIPTION
The main goal is to be able to pass custom ciphers from node.js (In App options) and have them used internally in uSockets

Followup of https://github.com/uNetworking/uSockets/pull/171