### PR TITLE
Declare TopicTreeMessage and TopicTreeBigMessage prior to use

### DIFF
--- a/src/WebSocketContextData.h
+++ b/src/WebSocketContextData.h
@@ -32,6 +32,8 @@
 namespace uWS {
 
 template <bool, bool, typename> struct WebSocket;
+struct TopicTreeMessage;
+struct TopicTreeBigMessage;
 
 /* todo: this looks identical to WebSocketBehavior, why not just std::move that entire thing in? */
 


### PR DESCRIPTION
`TopicTreeMessage` and `TopicTreeBigMessage` are defined in App.h. This means that if App.h doesn't come first somehow, then there will be an error as those definitions can't be found. So declare it here, just like it was done with `WebSocket` and let the actual definition come later.

I was able to get this behavior by only including HttpParser.h and HttpResponse.h, as I was building a helper library for my use case.