### PR TITLE
Move TopicTreeMessage and TopicTreeBigMessage to TopicTree.h

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -23,18 +23,6 @@
 #include <string_view>
 
 namespace uWS {
-    /* Type queued up when publishing */
-    struct TopicTreeMessage {
-        std::string message;
-        /*OpCode*/ int opCode;
-        bool compress;
-    };
-    struct TopicTreeBigMessage {
-        std::string_view message;
-        /*OpCode*/ int opCode;
-        bool compress;
-    };
-
     /* Safari 15.0 - 15.3 has a completely broken compression implementation (client_no_context_takeover not
      * properly implemented) - so we fully disable compression for this browser :-(
      * see https://github.com/uNetworking/uWebSockets/issues/1347 */

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -356,18 +356,6 @@ public:
     }
 };
 
-/* Type queued up when publishing */
-struct TopicTreeMessage {
-    std::string message;
-    /*OpCode*/ int opCode;
-    bool compress;
-};
-struct TopicTreeBigMessage {
-    std::string_view message;
-    /*OpCode*/ int opCode;
-    bool compress;
-};
-
 }
 
 #endif

--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -356,6 +356,18 @@ public:
     }
 };
 
+/* Type queued up when publishing */
+struct TopicTreeMessage {
+    std::string message;
+    /*OpCode*/ int opCode;
+    bool compress;
+};
+struct TopicTreeBigMessage {
+    std::string_view message;
+    /*OpCode*/ int opCode;
+    bool compress;
+};
+
 }
 
 #endif

--- a/src/WebSocketContextData.h
+++ b/src/WebSocketContextData.h
@@ -31,6 +31,18 @@
 
 namespace uWS {
 
+/* Type queued up when publishing */
+struct TopicTreeMessage {
+    std::string message;
+    /*OpCode*/ int opCode;
+    bool compress;
+};
+struct TopicTreeBigMessage {
+    std::string_view message;
+    /*OpCode*/ int opCode;
+    bool compress;
+};
+
 template <bool, bool, typename> struct WebSocket;
 
 /* todo: this looks identical to WebSocketBehavior, why not just std::move that entire thing in? */

--- a/src/WebSocketContextData.h
+++ b/src/WebSocketContextData.h
@@ -32,8 +32,6 @@
 namespace uWS {
 
 template <bool, bool, typename> struct WebSocket;
-struct TopicTreeMessage;
-struct TopicTreeBigMessage;
 
 /* todo: this looks identical to WebSocketBehavior, why not just std::move that entire thing in? */
 


### PR DESCRIPTION
`TopicTreeMessage` and `TopicTreeBigMessage` definitions are required prior to including App.h since I previously (#1507) changed it to do a forward declaration. The forward declaration created issues as other parts ended up accessing the structs, which require the definitions.