### PR TITLE
Fix reported content length for HttpResponse::endWithoutBody

### DIFF
--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -420,7 +420,7 @@ public:
     /* End without a body (no content-length) or end with a spoofed content-length. */
     void endWithoutBody(std::optional<size_t> reportedContentLength = std::nullopt, bool closeConnection = false) {
         if (reportedContentLength.has_value()) {
-            //internalEnd({nullptr, 0}, reportedContentLength.value(), false, true, closeConnection);
+            internalEnd({nullptr, 0}, reportedContentLength.value(), false, true, closeConnection);
         } else {
             internalEnd({nullptr, 0}, 0, false, false, closeConnection);
         }


### PR DESCRIPTION
Hey! 
I need to report a real size of a body in the HEAD response. It doesn't work without this patch.  
Thanks.