### PR TITLE
Fix [-Werror=format-truncation] compiler warning

### DIFF
--- a/src/LoopData.h
+++ b/src/LoopData.h
@@ -76,7 +76,7 @@ public:
             "Jan", "Feb", "Mar", "Apr", "May", "Jun",
             "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
         };
-        snprintf(date, 32, "%.3s, %.2d %.3s %d %.2d:%.2d:%.2d GMT",
+        snprintf(date, 32, "%.3s, %.2u %.3s %.4u %.2u:%.2u:%.2u GMT",
             wday_name[tstruct.tm_wday],
             tstruct.tm_mday % 99,
             mon_name[tstruct.tm_mon],


### PR DESCRIPTION
This PR fixes the following compiler warning:

```cpp
../subprojects/uwebsockets/include/uwebsockets/LoopData.h:79:62: error: ‘ GMT’ directive output may be truncated writing 4 bytes into a region of size between 2 and 16 [-Werror=format-truncation=]
   79 |         snprintf(date, 32, "%.3s, %.2d %.3s %d %.2d:%.2d:%.2d GMT",
      |                                                              ^~~~
```

The warning is because each occurrence of `%.2d` could potentially add a minus sign. Changing to `%.2u` makes this impossible and the warning disappears.

I use **GCC 10.3.0** on **Ubuntu 20.04**, the relevant compiler flags are:

```sh
-Wall -Winvalid-pch -Wextra -Werror -std=gnu++20
```