### PR TITLE
Add uws_loop_defer function to uWebsockets CAPI

### DIFF
--- a/capi/libuwebsockets.cpp
+++ b/capi/libuwebsockets.cpp
@@ -23,6 +23,7 @@
 #include "libuwebsockets.h"
 #include <string_view>
 #include "App.h"
+#include "ClientApp.h"
 #include <optional>
 extern "C"
 {
@@ -1321,5 +1322,13 @@ extern "C"
     struct us_loop_t *uws_get_loop_with_native(void *existing_native_loop)
     {
         return (struct us_loop_t *)uWS::Loop::get(existing_native_loop);
+    }
+    void uws_loop_defer(us_loop_t *loop, void( cb(void *user_data) ), void *user_data)
+    {
+        uWS::Loop *loop_instance = (uWS::Loop *)loop;
+        loop_instance->defer([cb, user_data](){
+            cb(user_data);
+        });
+
     }
 }

--- a/capi/libuwebsockets.h
+++ b/capi/libuwebsockets.h
@@ -250,6 +250,7 @@ extern "C"
 
     DLL_EXPORT struct us_loop_t *uws_get_loop();
     DLL_EXPORT struct us_loop_t *uws_get_loop_with_native(void* existing_native_loop);
+    DLL_EXPORT void uws_loop_defer(struct us_loop_t *loop, void( cb(void *user_data) ), void *user_data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello! 
I am working on Rust bindings to uWebSockets, and as far as I understand, defer is the only way to use the library in multiple threads (which is necessary in my case). 
So, this pull request adds a function `uws_loop_defer` to the CAPI.
Thank you for considering that PR. 