### PR TITLE
sprintf -> snprintf to silence compiler warnings about unsafe string …

### DIFF
--- a/capi/examples/Broadcast.c
+++ b/capi/examples/Broadcast.c
@@ -115,9 +115,9 @@ void on_timer_interval(void* data){
 
     int64_t millis = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 
-    
-    char* message = (char*)malloc((size_t)buffer_size("%ld", millis));
-    size_t message_length = sprintf(message, "%ld", millis);
+    size_t sz = buffer_size("%ld", millis);
+    char* message = (char*)malloc(sz);
+    size_t message_length = snprintf(message, sz, "%ld", millis);
 
     uws_publish(SSL, app, "broadcast", 9, message, message_length, uws_opcode_t::TEXT, false);
     free(message);

--- a/capi/examples/BroadcastEchoServer.c
+++ b/capi/examples/BroadcastEchoServer.c
@@ -88,8 +88,9 @@ void open_handler(uws_websocket_t *ws)
     for (int i = 0; i < data->topics_quantity; i++)
     {
 
-        char *topic = (char *)malloc((size_t)buffer_size("%ld-%d", (uintptr_t)ws, i));
-        size_t topic_length = sprintf(topic, "%ld-%d", (uintptr_t)ws, i);
+        size_t sz = buffer_size("%ld-%d", (uintptr_t)ws, i);
+        char *topic = (char *)malloc(sz);
+        size_t topic_length = snprintf(topic, sz, "%ld-%d", (uintptr_t)ws, i);
 
         topic_t *new_topic = (topic_t*) malloc(sizeof(topic_t));
         new_topic->length = topic_length;

--- a/src/AsyncSocket.h
+++ b/src/AsyncSocket.h
@@ -201,9 +201,9 @@ protected:
         unsigned char *b = (unsigned char *) binary.data();
 
         if (binary.length() == 4) {
-            ipLength = sprintf(buf, "%u.%u.%u.%u", b[0], b[1], b[2], b[3]);
+            ipLength = snprintf(buf, sizeof(buf), "%u.%u.%u.%u", b[0], b[1], b[2], b[3]);
         } else {
-            ipLength = sprintf(buf, "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+            ipLength = snprintf(buf, sizeof(buf), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
                 b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11],
                 b[12], b[13], b[14], b[15]);
         }


### PR DESCRIPTION
…functions

Compilers may warn about the use of unsafe string functions and users may question the use of sprintf(). Switching to snprintf removes the question about whether unsafe string functions are being used.

Note that the two cases that use buffer_size() were safe as buffer_size() was used during the allocation of the output buffer. Two other uses of sprintf() in the examples may not have been safe in all cases.