### PR TITLE
Support gcc7 - remove charconv

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -19,7 +19,6 @@
 #define UWS_APP_H
 
 #include <string>
-#include <charconv>
 #include <string_view>
 
 namespace uWS {
@@ -35,9 +34,14 @@ namespace uWS {
         if (posEnd == std::string_view::npos) return false;
 
         unsigned int minorVersion = 0;
-        auto result = std::from_chars(userAgent.data() + posStart, userAgent.data() + posEnd, minorVersion);
-        if (result.ec != std::errc()) return false;
-        if (result.ptr != userAgent.data() + posEnd) return false; // do not accept trailing chars
+        std::string minorVersionStr(userAgent.substr(posStart, posEnd - posStart));
+
+        try {
+            minorVersion = std::stoi(minorVersionStr);
+        } catch (const std::exception&) {
+            return false;
+        }
+
         if (minorVersion > 3) return false; // we target just Safari 15.0 - 15.3
 
         if (userAgent.find(" Safari/", posEnd) == std::string_view::npos) return false;


### PR DESCRIPTION
Hi!

Not sure which versions of the c++ spec you want to support or which versions of various compilers. But I noticed that uWS is not usable with gcc7. But the only reason for this (as far as I can tell) is that the charconv header is used, which is not implemented by gcc until gcc8. This PR removes the need for that header.

I could also do a marco if you want those that have charconv to use it and only have this change in other cases. Charconv of course is more efficient.