### PR TITLE
Fix uws_res_resume() API to call resume() instead of pause()

### DIFF
--- a/capi/libuwebsockets.cpp
+++ b/capi/libuwebsockets.cpp
@@ -1059,12 +1059,12 @@ extern "C"
         if (ssl)
         {
             uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-            uwsRes->pause();
+            uwsRes->resume();
         }
         else
         {
             uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-            uwsRes->pause();
+            uwsRes->resume();
         }
     }
 


### PR DESCRIPTION
I have tried out this fix and it seems to make the pause/resume functionality work correctly.  Addresses #1686 Thank you for considering it!