### PR TITLE
Feature / Adopt externally accepted sockets into uWebSockets.

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -575,6 +575,12 @@ public:
         return std::move(*this);
     }
 
+    /* adopt an externally accepted socket */
+    TemplatedApp &&adoptSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd) {
+        httpContext->adoptAcceptedSocket(accepted_fd);
+        return std::move(*this);
+    }
+
     TemplatedApp &&run() {
         uWS::run();
         return std::move(*this);

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -482,6 +482,11 @@ public:
     us_listen_socket_t *listen(const char *path, int options) {
         return us_socket_context_listen_unix(SSL, getSocketContext(), path, options, sizeof(HttpResponseData<SSL>));
     }
+
+    /* Adopt an externally accepted socket into this HttpContext */
+    us_socket_t *adoptAcceptedSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd) {
+        return us_adopt_accepted_socket(SSL, getSocketContext(), accepted_fd, sizeof(HttpResponseData<SSL>), 0, 0);
+    }
 };
 
 }


### PR DESCRIPTION
# Description

This allows for sockets that were obtained from an external `accept(2)` to be adopted into uWebSockets. 

Such sockets may come from another library, another external event-loop, or from a forked-server pattern, like [inetd](https://en.wikipedia.org/wiki/Inetd), [systemd-socket-activate](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-activate.html) etc.

This PR is based on https://github.com/uNetworking/uSockets/pull/214 for uSockets. 

Note: I'm unsure how Github handles PRs with submodules, hope I've done it right.

# Justification

A forked process serving a single websocket session can increase safety, as each user is isolated in a separate process. In addition it can do impersonation via [setuid(2)](https://www.man7.org/linux/man-pages/man2/setuid.2.html) to restrict access on the host to that of an authenticated user. The design can also interface legacy "single-user" back-end software. It can increase robustness, limiting the effects of crashes to one session.

This is similar to what libwebsockets does in its "socket adoption helpers":

https://libwebsockets.org/lws-api-doc-main/html/group__sock-adopt.html

# Instructions for use

The following is simplified code (no error checking) to show the forking pattern:

  ```C++
     // somewhere in a parent process, we listen and accept 
     listener = socket(PF_INET, SOCK_STREAM, 0);
      
      bzero(&srv_addr, sizeof(srv_addr));
      srv_addr.sin_family = AF_INET;
      srv_addr.sin_port = htons(port);
      srv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
      
      bind(listener,
                (const struct sockaddr *)&srv_addr,
                sizeof(srv_addr));
    
      listen(listener, 10);
    
      for (;;) {
        int websocket = accept4(listener, NULL, NULL, SOCK_CLOEXEC | SOCK_NONBLOCK);
        // needs to be non-blocking for sure 
        fcntl(websocket, F_SETFL, fcntl(websocket, F_GETFL, 0) | O_NONBLOCK);
    
        switch (fork()) {
        case -1:                        // Error
              close(websocket);     
              break;                      
    
        case 0:                         // Child 
              close(listener);         //  does not need the listener
              
              startApp(websocket);
        
              _exit(EXIT_SUCCESS);
    
        default:                       // Parent
              close(websocket);   // does not need the websocket 
              break
        }
      }
```

then `startApp()` would look something like this:

  ```C++

void startApp(int fd) {
    uWS::SSLApp({
         .cert_file_name = "cert.pem",
         .key_file_name = "key.pem"
      
    }).ws<UserData>("/*", {
  
          .message = [](auto *ws, std::string_view message, uWS::OpCode opCode) {
              ws->send(message, opCode);
          }
          .close = [&](auto *ws, int code, std::string_view message) {
               // this will be the last of it
               uWS::Loop::get()->defer([&](){
                   app.close();
                });
          },
    }).adoptSocket(fd)
    // run this one websocket session to the end
    .run();
}
```

The `adoptSocket()` can be combined with the usual `listen()`, so this would just be the first socket that launches the server process, such as in a [inetd](https://en.wikipedia.org/wiki/Inetd), [systemd-socket-activate](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-activate.html) pattern.
