### PR TITLE
Linux only: full system-wide install with uSockets + Hints for CMake users

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,8 @@ capi: default
 	./build capi
 
 install:
+	cp uSockets/uSockets.a "$(DESTDIR)$(prefix)/lib"
+	cp uSockets/src/libusockets.h "$(DESTDIR)$(prefix)/include"
 	mkdir -p "$(DESTDIR)$(prefix)/include/uWebSockets"
 	cp -r src/* "$(DESTDIR)$(prefix)/include/uWebSockets"
 

--- a/misc/READMORE.md
+++ b/misc/READMORE.md
@@ -38,11 +38,22 @@ There are a few compilation flags for µSockets (see its documentation), but com
 
 You can use the Makefile on Linux and macOS. It is simple to use and builds the examples for you. `WITH_OPENSSL=1 make` builds all examples with SSL enabled. Examples will fail to listen if cert and key cannot be found, so make sure to specify a path that works for you.
 
-### Steps
+### Steps for Linux
 ```sh
 git clone --resurse-submodules https://github.com/uNetworking/uWebSockets
 make # prepend variables if desired such as `WITH_OPENSSL` as mentioned above
 make install
+```
+
+_Note for Linux CMake users: make sure to include ZLIB as a dependency as well as `uSockets.a` static library (which was installed during `make install`)._
+
+Here is an example:
+```
+...
+find_library(USOCKETS_LIBRARY uSockets.a PATHS /usr/local/lib REQUIRED)
+find_package(ZLIB REQUIRED)
+target_link_libraries(${PROJECT_NAME} ${USOCKETS_LIBRARY} ZLIB::ZLIB)
+...
 ```
 
 ## User manual

--- a/misc/READMORE.md
+++ b/misc/READMORE.md
@@ -40,7 +40,7 @@ You can use the Makefile on Linux and macOS. It is simple to use and builds the 
 
 ### Steps for Linux
 ```sh
-git clone --resurse-submodules https://github.com/uNetworking/uWebSockets
+git clone --recurse-submodules https://github.com/uNetworking/uWebSockets
 make # prepend variables if desired such as `WITH_OPENSSL` as mentioned above
 make install
 ```

--- a/misc/READMORE.md
+++ b/misc/READMORE.md
@@ -38,6 +38,13 @@ There are a few compilation flags for µSockets (see its documentation), but com
 
 You can use the Makefile on Linux and macOS. It is simple to use and builds the examples for you. `WITH_OPENSSL=1 make` builds all examples with SSL enabled. Examples will fail to listen if cert and key cannot be found, so make sure to specify a path that works for you.
 
+### Steps
+```sh
+git clone --resurse-submodules https://github.com/uNetworking/uWebSockets
+make # prepend variables if desired such as `WITH_OPENSSL` as mentioned above
+make install
+```
+
 ## User manual
 
 ### uWS::App & uWS::SSLApp


### PR DESCRIPTION
Fixes: https://github.com/uNetworking/uWebSockets/issues/1600

1. Ensures that uSockets is installed with the `make install` command.
2. Gives hints as to the nuances with the git submodule for uSockets.
3. Gives hints on how to use with CMake.
