### PR TITLE
Replace unnecessary lambda for close event

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -382,14 +382,7 @@ public:
         webSocketContext->getExt()->droppedHandler = std::move(behavior.dropped);
         webSocketContext->getExt()->drainHandler = std::move(behavior.drain);
         webSocketContext->getExt()->subscriptionHandler = std::move(behavior.subscription);
-        webSocketContext->getExt()->closeHandler = std::move([closeHandler = std::move(behavior.close)](WebSocket<SSL, true, UserData> *ws, int code, std::string_view message) mutable {
-            if (closeHandler) {
-                closeHandler(ws, code, message);
-            }
-
-            /* Destruct user data after returning from close handler */
-            ((UserData *) ws->getUserData())->~UserData();
-        });
+        webSocketContext->getExt()->closeHandler = std::move(behavior.close);
         webSocketContext->getExt()->pingHandler = std::move(behavior.ping);
         webSocketContext->getExt()->pongHandler = std::move(behavior.pong);
 

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -241,6 +241,7 @@ public:
         if (webSocketContextData->closeHandler) {
             webSocketContextData->closeHandler(this, code, message);
         }
+        ((USERDATA *) this->getUserData())->~USERDATA();
     }
 
     /* Corks the response if possible. Leaves already corked socket be. */

--- a/src/WebSocketContext.h
+++ b/src/WebSocketContext.h
@@ -269,9 +269,11 @@ private:
                 webSocketContextData->topicTree->freeSubscriber(webSocketData->subscriber);
                 webSocketData->subscriber = nullptr;
 
+                auto *ws = (WebSocket<SSL, isServer, USERDATA> *) s;
                 if (webSocketContextData->closeHandler) {
-                    webSocketContextData->closeHandler((WebSocket<SSL, isServer, USERDATA> *) s, 1006, {(char *) reason, (size_t) code});
+                    webSocketContextData->closeHandler(ws, 1006, {(char *) reason, (size_t) code});
                 }
+                ((USERDATA *) ws->getUserData())->~USERDATA();
             }
 
             /* Destruct in-placed data struct */


### PR DESCRIPTION
The lambda is simply a wrapper to destruct UserData, which can instead be done by the caller, removing the need for it. In this case we also destruct UserData even if closeHandler is null, which would not have been done before.