### PR TITLE
Move deletion of topicTree to after use of the pointer in removePre/PostHandler

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -189,12 +189,12 @@ public:
 
         /* Delete TopicTree */
         if (topicTree) {
-            delete topicTree;
-
             /* And unregister loop callbacks */
             /* We must unregister any loop post handler here */
             Loop::get()->removePostHandler(topicTree);
             Loop::get()->removePreHandler(topicTree);
+
+	    delete topicTree;
         }
     }
 


### PR DESCRIPTION
This fails clang-tidy and is probably a reasonable thing to change