### PR TITLE
Add missing include cstdint in BloomFilter.h

### DIFF
--- a/src/BloomFilter.h
+++ b/src/BloomFilter.h
@@ -21,6 +21,7 @@
 /* This filter has no false positives or collisions for the standard
  * and non-standard common request headers */
 
+#include <cstdint>
 #include <string_view>
 #include <bitset>
 


### PR DESCRIPTION
`BloomFilter.h` uses `int32_t`, so it needs to include the `cstdint` header.