### PR TITLE
Update TopicTree.h to include missing header file for std::terminate

### DIFF
--- a/src/TopicTree.h
+++ b/src/TopicTree.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <set>
 #include <string>
+#include <exception>
 
 namespace uWS {
 


### PR DESCRIPTION
Missing header file "exception". This causes a compiler error on at least MacOS when including the Websocket.h header file.