### PR TITLE
Expose remote port api

### DIFF
--- a/src/AsyncSocket.h
+++ b/src/AsyncSocket.h
@@ -230,6 +230,12 @@ protected:
         return addressAsText(getRemoteAddress());
     }
 
+    /* Returns the remote port number or -1 on failure */
+    unsigned int getRemotePort() {
+        int port = us_socket_remote_port(SSL, (us_socket_t *) this);
+        return (unsigned int) port;
+    }
+
     /* Write in three levels of prioritization: cork-buffer, syscall, socket-buffer. Always drain if possible.
      * Returns pair of bytes written (anywhere) and whether or not this call resulted in the polling for
      * writable (or we are in a state that implies polling for writable). */

--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -229,6 +229,10 @@ public:
     std::string_view getProxiedRemoteAddressAsText() {
         return Super::addressAsText(getProxiedRemoteAddress());
     }
+
+    unsigned int getProxiedRemotePort() {
+        return getHttpResponseData()->proxyParser.getSourcePort();
+    }
 #endif
 
     /* Manually upgrade to WebSocket. Typically called in upgrade handler. Immediately calls open handler.
@@ -355,6 +359,7 @@ public:
     /* See AsyncSocket */
     using Super::getRemoteAddress;
     using Super::getRemoteAddressAsText;
+    using Super::getRemotePort;
     using Super::getNativeHandle;
 
     /* Throttle reads and writes */

--- a/src/ProxyParser.h
+++ b/src/ProxyParser.h
@@ -91,6 +91,22 @@ public:
         }
     }
 
+    unsigned int getSourcePort() {
+
+        // UNSPEC family and protocol
+        if (family == 0) {
+            return {};
+        }
+
+        if ((family & 0xf0) >> 4 == 1) {
+            /* Family 1 is INET4 */
+            return addr.ipv4_addr.src_port;
+        } else {
+            /* Family 2 is INET6 */
+            return addr.ipv6_addr.src_port;
+        }
+    }
+
     /* Returns [done, consumed] where done = false on failure */
     std::pair<bool, unsigned int> parse(std::string_view data) {
 

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -58,6 +58,7 @@ public:
     using Super::getBufferedAmount;
     using Super::getRemoteAddress;
     using Super::getRemoteAddressAsText;
+    using Super::getRemotePort;
     using Super::getNativeHandle;
 
     /* WebSocket close cannot be an alias to AsyncSocket::close since


### PR DESCRIPTION
Exposes the remote socket port to the upper layers

Related to issue: https://github.com/uNetworking/uWebSockets.js/issues/1160