### PR TITLE
Add missing cstdint include for uint64_t

### DIFF
--- a/src/ChunkedEncoding.h
+++ b/src/ChunkedEncoding.h
@@ -20,6 +20,7 @@
 
 /* Independent chunked encoding parser, used by HttpParser. */
 
+#include <cstdint>
 #include <string>
 #include <cstring>
 #include <algorithm>


### PR DESCRIPTION
Building on Alpine Linux, including `App.h` gives these errors:
```
In file included from ../subprojects/uwebsockets/src/HttpParser.h:32:
../subprojects/uwebsockets/src/ChunkedEncoding.h:32:15: error: unknown type name 'uint64_t'
   32 |     constexpr uint64_t STATE_HAS_SIZE = 1ull << (sizeof(uint64_t) * 8 - 1);//0x80000000;
      |               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:32:57: error: use of undeclared identifier 'uint64_t'
   32 |     constexpr uint64_t STATE_HAS_SIZE = 1ull << (sizeof(uint64_t) * 8 - 1);//0x80000000;
      |                                                         ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:33:15: error: unknown type name 'uint64_t'
   33 |     constexpr uint64_t STATE_IS_CHUNKED = 1ull << (sizeof(uint64_t) * 8 - 2);//0x40000000;
      |               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:33:59: error: use of undeclared identifier 'uint64_t'
   33 |     constexpr uint64_t STATE_IS_CHUNKED = 1ull << (sizeof(uint64_t) * 8 - 2);//0x40000000;
      |                                                           ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:34:15: error: unknown type name 'uint64_t'
   34 |     constexpr uint64_t STATE_SIZE_MASK = ~(3ull << (sizeof(uint64_t) * 8 - 2));//0x3FFFFFFF;
      |               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:34:60: error: use of undeclared identifier 'uint64_t'
   34 |     constexpr uint64_t STATE_SIZE_MASK = ~(3ull << (sizeof(uint64_t) * 8 - 2));//0x3FFFFFFF;
      |                                                            ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:35:15: error: unknown type name 'uint64_t'
   35 |     constexpr uint64_t STATE_IS_ERROR = ~0ull;//0xFFFFFFFF;
      |               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:36:15: error: unknown type name 'uint64_t'
   36 |     constexpr uint64_t STATE_SIZE_OVERFLOW = 0x0Full << (sizeof(uint64_t) * 8 - 8);//0x0F000000;
      |               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:36:65: error: use of undeclared identifier 'uint64_t'
   36 |     constexpr uint64_t STATE_SIZE_OVERFLOW = 0x0Full << (sizeof(uint64_t) * 8 - 8);//0x0F000000;
      |                                                                 ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:38:12: error: unknown type name 'uint64_t'
   38 |     inline uint64_t chunkSize(uint64_t state) {
      |            ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:38:31: error: unknown type name 'uint64_t'
   38 |     inline uint64_t chunkSize(uint64_t state) {
      |                               ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:43:58: error: unknown type name 'uint64_t'
   43 |     inline void consumeHexNumber(std::string_view &data, uint64_t &state) {
      |                                                          ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:62:13: error: unknown type name 'uint64_t'
   62 |             uint64_t bits = /*state &*/ STATE_IS_CHUNKED;
      |             ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:81:30: error: unknown type name 'uint64_t'
   81 |     inline void decChunkSize(uint64_t &state, unsigned int by) {
      |                              ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:90:30: error: unknown type name 'uint64_t'
   90 |     inline bool hasChunkSize(uint64_t state) {
      |                              ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:95:42: error: unknown type name 'uint64_t'
   95 |     inline bool isParsingChunkedEncoding(uint64_t state) {
      |                                          ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:99:49: error: unknown type name 'uint64_t'
   99 |     inline bool isParsingInvalidChunkedEncoding(uint64_t state) {
      |                                                 ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:104:81: error: unknown type name 'uint64_t'
  104 |     static std::optional<std::string_view> getNextChunk(std::string_view &data, uint64_t &state, bool trailer = false) {
      |                                                                                 ^
../subprojects/uwebsockets/src/ChunkedEncoding.h:170:21: error: unknown type name 'uint64_t'
  170 |                     uint64_t maximalAppEmit = chunkSize(state) - 2;
      |                     ^
```

This PR adds an include for cstdint to ensure the definition of uint64_t is available.