### PR TITLE
Provide access to existing parameter names

### DIFF
--- a/src/HttpParser.h
+++ b/src/HttpParser.h
@@ -190,6 +190,18 @@ public:
         }
     }
 
+    /* Access to parameter names, not used internally */
+    std::vector<std::string> getParameterNames() const {
+        if (!currentParameterOffsets) {
+            return {};
+        }
+        std::vector<std::string> names;
+        names.reserve(currentParameterOffsets->size());
+        for (const auto& it : *currentParameterOffsets) {
+            names.push_back(it.first);
+        }
+        return names;
+    }
 };
 
 struct HttpParser {


### PR DESCRIPTION
This can be useful in higher level abstractions that outlive HttpRequest.

If you'd prefer a different solution like making the currentParameterOffsets accessible and let the user do the copy please let me know.