### PR TITLE
Add callback handler to report internal HTTP parsing errors (431, 400, 505)

### DIFF
--- a/fuzzing/Http.cpp
+++ b/fuzzing/Http.cpp
@@ -135,6 +135,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
             /* Return ok */
             return user;
 
+        }, [](uWS::HttpRequest */*req*/, unsigned int /*errorCode*/) {
         });
 
         if (!returnedUser) {

--- a/src/App.h
+++ b/src/App.h
@@ -147,6 +147,13 @@ public:
         return std::move(static_cast<TemplatedApp &&>(*this));
     }
 
+    /* Attaches an error handler for internal HTTP parsing errors */
+    TemplatedApp &&onHttpParsingError(MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> &&errorHandler) {
+        httpContext->onHttpParsingError(std::move(errorHandler));
+
+        return std::move(static_cast<TemplatedApp &&>(*this));
+    }
+
     /* Same as publish, but takes a prepared message */
     bool publishPrepared(std::string_view topic, PreparedMessage &preparedMessage) {
         /* It is assumed by heuristics that a prepared message ought to be big,

--- a/src/App.h
+++ b/src/App.h
@@ -147,9 +147,9 @@ public:
         return std::move(static_cast<TemplatedApp &&>(*this));
     }
 
-    /* Attaches an error handler for internal HTTP parsing errors */
-    TemplatedApp &&onHttpParsingError(MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> &&errorHandler) {
-        httpContext->onHttpParsingError(std::move(errorHandler));
+    /* Attaches a log handler for HTTP parsing errors */
+    TemplatedApp &&log(MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> &&logHandler) {
+        httpContext->log(std::move(logHandler));
 
         return std::move(static_cast<TemplatedApp &&>(*this));
     }

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -442,8 +442,8 @@ public:
     }
 
     /* Register an HTTP parsing error handler */
-    void onHttpParsingError(MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> &&errorHandler) {
-        getSocketContextData()->httpParsingErrorHandler = std::move(errorHandler);
+    void log(MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> &&logHandler) {
+        getSocketContextData()->httpParsingErrorHandler = std::move(logHandler);
     }
 
     /* Register an HTTP route handler acording to URL pattern */

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -256,20 +256,7 @@ private:
                 /* Call the high-level error handler if one is registered */
                 if (httpContextData->httpParsingErrorHandler) {
                     /* Map internal error codes to HTTP status codes and response bodies */
-                    int statusCode;
-                    switch (errorCode) {
-                        case HTTP_ERROR_505_HTTP_VERSION_NOT_SUPPORTED:
-                            statusCode = 505;
-                            break;
-                        case HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE:
-                            statusCode = 431;
-                            break;
-                        case HTTP_ERROR_400_BAD_REQUEST:
-                        default:
-                            statusCode = 400;
-                            break;
-                    }
-                    httpContextData->httpParsingErrorHandler(httpRequest, statusCode, httpErrorResponses[errorCode]);
+                    httpContextData->httpParsingErrorHandler(httpRequest, httpErrorStatusCodes[errorCode], httpErrorResponses[errorCode]);
                 }
             });
 

--- a/src/HttpContextData.h
+++ b/src/HttpContextData.h
@@ -36,6 +36,9 @@ private:
     std::vector<MoveOnlyFunction<void(HttpResponse<SSL> *, int)>> filterHandlers;
 
     MoveOnlyFunction<void(const char *hostname)> missingServerNameHandler;
+    
+    /* HTTP parsing error handler */
+    MoveOnlyFunction<void(HttpRequest *, int, std::string_view)> httpParsingErrorHandler;
 
     struct RouterData {
         HttpResponse<SSL> *httpResponse;

--- a/src/HttpErrors.h
+++ b/src/HttpErrors.h
@@ -30,6 +30,13 @@ enum HttpError {
 
 #ifndef UWS_HTTPRESPONSE_NO_WRITEMARK
 
+static const int httpErrorStatusCodes[] = {
+    400, /* Zeroth place (unused) */
+    505, /* HTTP_ERROR_505_HTTP_VERSION_NOT_SUPPORTED */
+    431, /* HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE */
+    400  /* HTTP_ERROR_400_BAD_REQUEST */
+};
+
 /* Returned parser errors match this LUT. */
 static const std::string_view httpErrorResponses[] = {
     "", /* Zeroth place is no error so don't use it */

--- a/src/HttpParser.h
+++ b/src/HttpParser.h
@@ -614,7 +614,7 @@ private:
     }
 
 public:
-    std::pair<unsigned int, void *> consumePostPadded(char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler, MoveOnlyFunction<void(HttpRequest *, unsigned int)> &&errorHandler = nullptr) {
+    std::pair<unsigned int, void *> consumePostPadded(char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler, MoveOnlyFunction<void(HttpRequest *, unsigned int)> &&errorHandler) {
 
         /* This resets BloomFilter by construction, but later we also reset it again.
          * Optimize this to skip resetting twice (req could be made global) */
@@ -629,9 +629,7 @@ public:
                     dataHandler(user, chunk, chunk.length() == 0);
                 }
                 if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {
-                    if (errorHandler) {
-                        errorHandler(&req, HTTP_ERROR_400_BAD_REQUEST);
-                    }
+                    errorHandler(&req, HTTP_ERROR_400_BAD_REQUEST);
                     return {HTTP_ERROR_400_BAD_REQUEST, FULLPTR};
                 }
                 data = (char *) dataToConsume.data();
@@ -669,9 +667,7 @@ public:
             // break here on break
             std::pair<unsigned int, void *> consumed = fenceAndConsumePostPadded<true>(fallback.data(), (unsigned int) fallback.length(), user, reserved, &req, requestHandler, dataHandler);
             if (consumed.second != user) {
-                if (errorHandler) {
-                    errorHandler(&req, consumed.first);
-                }
+                errorHandler(&req, consumed.first);
                 return consumed;
             }
 
@@ -692,9 +688,7 @@ public:
                             dataHandler(user, chunk, chunk.length() == 0);
                         }
                         if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {
-                            if (errorHandler) {
-                              errorHandler(&req, HTTP_ERROR_400_BAD_REQUEST);
-                            }
+                            errorHandler(&req, HTTP_ERROR_400_BAD_REQUEST);
                             return {HTTP_ERROR_400_BAD_REQUEST, FULLPTR};
                         }
                         data = (char *) dataToConsume.data();
@@ -722,9 +716,7 @@ public:
 
             } else {
                 if (fallback.length() == MAX_FALLBACK_SIZE) {
-                    if (errorHandler) {
-                        errorHandler(&req, HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE);
-                    }
+                    errorHandler(&req, HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE);
                     return {HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, FULLPTR};
                 }
                 return {0, user};
@@ -733,9 +725,7 @@ public:
 
         std::pair<unsigned int, void *> consumed = fenceAndConsumePostPadded<false>(data, length, user, reserved, &req, requestHandler, dataHandler);
         if (consumed.second != user) {
-            if (errorHandler) {
-                errorHandler(&req, consumed.first);
-            }
+            errorHandler(&req, consumed.first);
             return consumed;
         }
 
@@ -746,9 +736,7 @@ public:
             if (length < MAX_FALLBACK_SIZE) {
                 fallback.append(data, length);
             } else {
-                if (errorHandler) {
-                    errorHandler(&req, HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE);
-                }
+                errorHandler(&req, HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE);
                 return {HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, FULLPTR};
             }
         }

--- a/tests/HttpParser.cpp
+++ b/tests/HttpParser.cpp
@@ -31,6 +31,7 @@ int main() {
         /* Return ok */
         return user;
 
+    }, [](uWS::HttpRequest */*req*/, unsigned int /*errorCode*/) {
     });
 
     std::cout << "HTTP DONE" << std::endl;


### PR DESCRIPTION
In order to track all requests in my project, I also want to track incoming requests that produce an internal http parsing error (mainly 431 Request Header Fields Too Large). As internal parsing errors result in response being written to the socket and closing the socket, there is no notion of these requests in the application.

By adding a callback handler, the application can be informed of requests that produced an internal error, allowing for an application to keep track of these requests and keep metrics on that.