### PR TITLE
Fix rule-of-5 for uApp

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -239,6 +239,15 @@ public:
         });
     }
 
+    TemplatedApp& operator=(const TemplatedApp&) = delete;
+
+    TemplatedApp& operator=(TemplatedApp&& other) {
+        std::swap(this->httpContext, other.httpContext);
+        std::swap(this->topicTree, other.topicTree);
+        std::swap(this->webSocketContextDeleters, other.webSocketContextDeleters);
+        std::swap(this->webSocketContexts, other.webSocketContexts);
+    }
+
     bool constructorFailed() {
         return !httpContext;
     }


### PR DESCRIPTION
The uApp defines copy/move constructors but not assign operators. This violates the rule of 3/5.
Fixes #1905 