### PR TITLE
adoptSocket: add optional ip parameter

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -593,7 +593,7 @@ public:
     }
 
     /* Register event handler for accepted FD. Can be used together with adoptSocket. */
-    TemplatedApp &&preOpen(LIBUS_SOCKET_DESCRIPTOR (*handler)(struct us_socket_context_t *, LIBUS_SOCKET_DESCRIPTOR)) {
+    TemplatedApp &&preOpen(LIBUS_SOCKET_DESCRIPTOR (*handler)(struct us_socket_context_t *, LIBUS_SOCKET_DESCRIPTOR, char *, int)) {
         httpContext->onPreOpen(handler);
         return std::move(static_cast<TemplatedApp &&>(*this));
     }
@@ -614,7 +614,7 @@ public:
         /* Add this app to httpContextData list over child apps and set onPreOpen */
         httpContext->getSocketContextData()->childApps.push_back((void *) app);
         
-        httpContext->onPreOpen([](struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd) -> LIBUS_SOCKET_DESCRIPTOR {
+        httpContext->onPreOpen([](struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd, char *ip, int ip_length) -> LIBUS_SOCKET_DESCRIPTOR {
             
             HttpContext<SSL> *httpContext = (HttpContext<SSL> *) context;
 
@@ -634,9 +634,9 @@ public:
             //std::cout << "Loop is " << receivingApp->getLoop() << std::endl;
 
 
-            receivingApp->getLoop()->defer([fd, receivingApp]() {
+            receivingApp->getLoop()->defer([fd, ipStore = std::string(ip, ip + ip_length), receivingApp]() {
                 //std::cout << "About to adopt socket " << fd << " on receivingApp " << receivingApp << std::endl;
-                receivingApp->adoptSocket(fd);
+                receivingApp->adoptSocket(fd, std::string_view(ipStore));
                 //std::cout << "Done " << std::endl;
             });
 
@@ -650,8 +650,8 @@ public:
     }
 
     /* adopt an externally accepted socket */
-    TemplatedApp &&adoptSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd) {
-        httpContext->adoptAcceptedSocket(accepted_fd);
+    TemplatedApp &&adoptSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd, std::string_view ip = std::string_view()) {
+        httpContext->adoptAcceptedSocket(accepted_fd, (char *) ip.data(), (int) ip.length());
         return std::move(static_cast<TemplatedApp &&>(*this));
     }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -506,13 +506,13 @@ public:
         return us_socket_context_listen_unix(SSL, getSocketContext(), path, options, sizeof(HttpResponseData<SSL>));
     }
 
-    void onPreOpen(LIBUS_SOCKET_DESCRIPTOR (*handler)(struct us_socket_context_t *, LIBUS_SOCKET_DESCRIPTOR)) {
+    void onPreOpen(LIBUS_SOCKET_DESCRIPTOR (*handler)(struct us_socket_context_t *, LIBUS_SOCKET_DESCRIPTOR, char *, int)) {
         us_socket_context_on_pre_open(SSL, getSocketContext(), handler);
     }
 
     /* Adopt an externally accepted socket into this HttpContext */
-    us_socket_t *adoptAcceptedSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd) {
-        return us_adopt_accepted_socket(SSL, getSocketContext(), accepted_fd, sizeof(HttpResponseData<SSL>), 0, 0);
+    us_socket_t *adoptAcceptedSocket(LIBUS_SOCKET_DESCRIPTOR accepted_fd, char *ip, int ip_length) {
+        return us_adopt_accepted_socket(SSL, getSocketContext(), accepted_fd, sizeof(HttpResponseData<SSL>), ip, ip_length);
     }
 };
 

--- a/src/LocalCluster.h
+++ b/src/LocalCluster.h
@@ -34,7 +34,7 @@ struct LocalCluster {
 
                 cb(*app);
                 
-                app->preOpen([](struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd) -> LIBUS_SOCKET_DESCRIPTOR {
+                app->preOpen([](struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd, char *ip, int ip_length) -> LIBUS_SOCKET_DESCRIPTOR {
 
                     std::ignore = context;
 
@@ -42,8 +42,8 @@ struct LocalCluster {
                     //std::cout << "About to load balance " << fd << " to " << roundRobin << std::endl;
 
                     auto receivingApp = apps[roundRobin];
-                    apps[roundRobin]->getLoop()->defer([fd, receivingApp]() {
-                        receivingApp->adoptSocket(fd);
+                    apps[roundRobin]->getLoop()->defer([fd, ipStore = std::string(ip, ip + ip_length), receivingApp]() {
+                        receivingApp->adoptSocket(fd, std::string_view(ipStore));
                     });
 
                     roundRobin = (roundRobin + 1) % hardwareConcurrency;


### PR DESCRIPTION
Related to uWS.js issue [1257](https://github.com/uNetworking/uWebSockets.js/issues/1257).
Depends on uSockets PR [251](https://github.com/uNetworking/uSockets/pull/251).

Update `adoptSocket()` to accept an optional IP parameter.
Update LocalCluster and `addChildApp()` to retrieve the IP on pre_open and pass it to `adoptSocket()`.
Allowing the IP to be correctly set in the uSockets open handler for the adopted socket.

If someone accepts external FD, needs the IP on the request and uses the UWS_REMOTE_ADDRESS_USERSPACE cache, they have to pass the IP to adoptSocket().