### PR TITLE
Fix cork() closing a WebSocket that was upgraded asynchronously

### DIFF
--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -532,6 +532,9 @@ public:
     HttpResponse *cork(MoveOnlyFunction<void()> &&handler) {
         if (!Super::isCorked() && Super::canCork()) {
             LoopData *loopData = Super::getLoopData();
+            /* Remember our socket context so we can detect a WebSocket upgrade in the
+             * handler even when the poll realloc kept our address (see below). */
+            struct us_socket_context_t *preCorkContext = us_socket_context(SSL, (struct us_socket_t *) this);
             Super::cork();
             handler();
 
@@ -552,7 +555,11 @@ public:
 
             /* If we are no longer an HTTP socket then early return the new "this".
              * We don't want to even overwrite timeout as it is set in upgrade already. */
-            if (this != newCorkedSocket) {
+            /* The pointer check alone is not enough: us_socket_context_adopt_socket() can
+             * realloc the poll in place, leaving the upgraded WebSocket at our old address
+             * (this == newCorkedSocket). The socket context always changes on upgrade. */
+            if (this != newCorkedSocket ||
+                us_socket_context(SSL, (struct us_socket_t *) newCorkedSocket) != preCorkContext) {
                 return static_cast<HttpResponse *>(newCorkedSocket);
             }
 


### PR DESCRIPTION
## Problem

Completing a WebSocket upgrade asynchronously, i.e. `res->cork([](){ res->upgrade(...); })`
from a timer or after an await (as in `examples/UpgradeAsync.cpp`), can close the socket right
after the `.open` event, with no error and without the app calling `close()`. Synchronous
upgrades (`examples/UpgradeSync.cpp`) are not affected.

## Cause

`HttpResponse::cork()` runs its post-response HTTP logic after the handler and skips it on
upgrade with `if (this != newCorkedSocket)`. `upgrade()` -> `us_socket_context_adopt_socket()`
-> `us_poll_resize()` calls `realloc()`. When `sizeof(WebSocketData) + sizeof(UserData) <=
sizeof(HttpResponseData)` the block shrinks and glibc returns the same pointer, so
`this == newCorkedSocket` and the upgrade is not detected. `cork()` then reads
`HttpResponseData::state` from memory that is now `WebSocketData`; if that reads
`HTTP_CONNECTION_CLOSE` set with `HTTP_RESPONSE_PENDING` clear it runs `shutdown()` + `close()`.

The sync path is safe because `HttpContext` finishes the upgraded socket through
`httpContextData->upgradedWebSocket` (set only when `isParsingHttp`); only the async path
relies on the pointer comparison.

## Fix

The pointer check is not reliable after an in-place realloc. Also compare the socket context,
which always changes on upgrade. One extra `us_socket_context()` read per `cork()`.

## Reproduce

Build (Linux, no SSL, no zlib):

```
cc  -DLIBUS_NO_SSL -std=c11  -IuSockets/src -O2 -c uSockets/src/bsd.c uSockets/src/context.c \
    uSockets/src/loop.c uSockets/src/socket.c uSockets/src/udp.c uSockets/src/eventing/epoll_kqueue.c
c++ -DLIBUS_NO_SSL -DUWS_NO_ZLIB -std=c++20 -IuSockets/src -Isrc -O2 repro.cpp *.o -o repro
```

Run `./repro &` then `node raw_ws_client.js`.

On master `8a1f360`, stock uWS closes every connection right after `.open`:

```
[server] .close code=1006 lived=0ms   <<< SPURIOUS: cork() closed a just-upgraded WebSocket
BUG REPRODUCED: the WebSocket upgraded (101) and the open handler ran (we received "hello"),
but the server closed the connection right after with no error and no close() call.
```

With this patch, every connection stays open.

<details>
<summary><code>repro.cpp</code></summary>

```cpp
/* Standalone reproduction of a spurious-close bug in uWS::HttpResponse::cork()
 * when a WebSocket upgrade is completed ASYNCHRONOUSLY -- i.e.
 *     res->cork([]{ res->upgrade(...); });
 * is called OUTSIDE the HttpContext data callback, exactly as uWebSockets' own
 * examples/UpgradeAsync.cpp recommends (from a timer / after an await).
 *
 * A freshly-established WebSocket is torn down ~1ms after its .open event, with
 * no error and without the application calling close().
 *
 * Root cause (src/HttpResponse.h, HttpResponse::cork()):
 *   cork() runs post-response HTTP logic after the handler returns. It detects an
 *   in-handler upgrade with `if (this != newCorkedSocket)`. The comment there notes
 *   the upgrade "caused a realloc", assuming the socket always MOVES. But
 *   us_socket_context_adopt_socket() -> us_poll_resize() calls realloc(); when the
 *   WebSocket extension is <= the HttpResponse extension the block SHRINKS and glibc
 *   returns the SAME pointer. Then this == newCorkedSocket, the upgrade goes
 *   undetected, and cork() reads HttpResponseData::state from memory that is now a
 *   WebSocket. If those bytes have HTTP_CONNECTION_CLOSE set and HTTP_RESPONSE_PENDING
 *   clear, it shutdown()+close()s the just-upgraded WebSocket.
 *
 * To make the demo deterministic the client sends "Connection: close", which sets
 * HTTP_CONNECTION_CLOSE on the real HttpResponseData::state before the upgrade; that
 * flag survives the in-place shrink and is what cork() misreads. In production the
 * same close fires under a normal "Connection: Upgrade" handshake whenever the
 * per-socket user data (or freed tail bytes) happen to have bit 4 set at the state
 * offset -- which is how we hit it intermittently under load in a real server.
 *
 * Build (Linux, no SSL, no zlib):
 *   cc  -DLIBUS_NO_SSL -std=c11 -IuSockets/src -O2 -c uSockets/src/bsd.c uSockets/src/context.c \
 *       uSockets/src/loop.c uSockets/src/socket.c uSockets/src/udp.c uSockets/src/eventing/epoll_kqueue.c
 *   c++ -DLIBUS_NO_SSL -DUWS_NO_ZLIB -std=c++20 -IuSockets/src -Isrc -O2 repro.cpp *.o -o repro
 *   ./repro
 * Then: node raw_ws_client.js
 */
#include "App.h"
#include <iostream>
#include <chrono>

static long long nowMs() {
    return std::chrono::duration_cast<std::chrono::milliseconds>(
        std::chrono::steady_clock::now().time_since_epoch()).count();
}

int main() {
    /* Small per-connection user data (as in examples/UpgradeAsync.cpp). Because
     * sizeof(WebSocketData) + sizeof(PerSocketData) < sizeof(HttpResponseData), the
     * poll realloc during adopt SHRINKS and glibc returns the SAME pointer -> the
     * in-place case that defeats cork()'s `this != newCorkedSocket` upgrade check. */
    struct PerSocketData { long long openMs; };

    uWS::App().ws<PerSocketData>("/*", {
        .compression = uWS::DISABLED,
        .maxPayloadLength = 16 * 1024,
        .idleTimeout = 120,
        .maxBackpressure = 1024 * 1024,

        /* Async upgrade, identical in shape to examples/UpgradeAsync.cpp: copy the
         * handshake headers, register onAborted, then complete the upgrade on a later
         * loop iteration via res->cork([]{ res->upgrade(...); }). */
        .upgrade = [](auto *res, auto *req, auto *context) {
            struct UpgradeData {
                std::string secWebSocketKey, secWebSocketProtocol, secWebSocketExtensions;
                struct us_socket_context_t *context;
                decltype(res) httpRes;
                bool aborted = false;
            } *upgradeData = new UpgradeData {
                std::string(req->getHeader("sec-websocket-key")),
                std::string(req->getHeader("sec-websocket-protocol")),
                std::string(req->getHeader("sec-websocket-extensions")),
                context, res
            };
            res->onAborted([=]() { upgradeData->aborted = true; });

            struct us_loop_t *loop = (struct us_loop_t *) uWS::Loop::get();
            struct us_timer_t *t = us_create_timer(loop, 0, sizeof(UpgradeData *));
            memcpy(us_timer_ext(t), &upgradeData, sizeof(UpgradeData *));
            us_timer_set(t, [](struct us_timer_t *t) {
                UpgradeData *upgradeData;
                memcpy(&upgradeData, us_timer_ext(t), sizeof(UpgradeData *));
                if (!upgradeData->aborted) {
                    upgradeData->httpRes->cork([upgradeData]() {
                        upgradeData->httpRes->template upgrade<PerSocketData>(
                            { .openMs = 0 },
                            upgradeData->secWebSocketKey,
                            upgradeData->secWebSocketProtocol,
                            upgradeData->secWebSocketExtensions,
                            upgradeData->context);
                    });
                }
                delete upgradeData;
                us_timer_close(t);
            }, 1, 0);
        },

        .open = [](auto *ws) {
            /* The upgrade succeeded (101 + this open event). Record the time and send
             * a frame so the client can tell "alive" from "closed right after open". */
            static_cast<PerSocketData *>(ws->getUserData())->openMs = nowMs();
            ws->send("hello", uWS::OpCode::TEXT);
        },
        .message = [](auto *ws, std::string_view m, uWS::OpCode op) { ws->send(m, op); },
        .close = [](auto *ws, int code, std::string_view) {
            long long lived = nowMs() - static_cast<PerSocketData *>(ws->getUserData())->openMs;
            std::cout << "[server] .close code=" << code << " lived=" << lived << "ms"
                      << (lived < 100 ? "   <<< SPURIOUS: cork() closed a just-upgraded WebSocket" : "")
                      << std::endl;
        }
    }).listen(9001, [](auto *ls) {
        std::cout << "sizeof(HttpResponseData<false>)=" << sizeof(uWS::HttpResponseData<false>)
                  << "  sizeof(WebSocketData)=" << sizeof(uWS::WebSocketData)
                  << "  sizeof(WebSocketData+PerSocketData)=" << (sizeof(uWS::WebSocketData) + sizeof(PerSocketData))
                  << "  -> upgrade realloc "
                  << ((sizeof(uWS::WebSocketData) + sizeof(PerSocketData) <= sizeof(uWS::HttpResponseData<false>))
                        ? "SHRINKS, stays in place (this == newCorkedSocket)" : "grows")
                  << std::endl;
        std::cout << (ls ? "listening on :9001" : "FAILED to listen") << std::endl;
    }).run();
}
```
</details>

<details>
<summary><code>raw_ws_client.js</code></summary>

```js
// Dependency-free raw WebSocket client. Connects to the repro server, performs
// the handshake, and reports whether the freshly-upgraded socket is spuriously
// closed right after the open event.
//   node raw_ws_client.js [host] [port]
const net = require('net');
const host = process.argv[2] || '127.0.0.1';
const port = parseInt(process.argv[3] || '9001', 10);

const s = net.connect(port, host);
let buf = Buffer.alloc(0);
let got101 = false, gotHello = false, openAt = 0, done = false;

function finish(msg, code) {
  if (done) return; done = true;
  console.log(msg);
  try { s.destroy(); } catch {}
  process.exit(code);
}

s.on('connect', () => {
  // NOTE: "Connection: close" (5 chars) makes uWS flag the request HTTP_CONNECTION_CLOSE.
  // That is what makes this reproduction deterministic and offset-independent: the flag is
  // set on the real HttpResponseData::state, which survives the (in-place, shrinking) adopt
  // realloc, so cork()'s post-upgrade misread sees it and closes the freshly-upgraded socket.
  // (In production the same close fires under a normal "Connection: Upgrade" handshake when
  // foreign bytes in the per-socket user data happen to have bit 4 set at the state offset.)
  const connHeader = process.env.CONN || 'close';
  s.write(
    'GET / HTTP/1.1\r\n' +
    `Host: ${host}:${port}\r\n` +
    'Upgrade: websocket\r\n' +
    `Connection: ${connHeader}\r\n` +
    'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n' +
    'Sec-WebSocket-Version: 13\r\n\r\n'
  );
});

s.on('data', (d) => {
  buf = Buffer.concat([buf, d]);
  if (!got101) {
    const i = buf.indexOf('\r\n\r\n');
    if (i < 0) return;
    const statusLine = buf.slice(0, buf.indexOf('\r\n')).toString();
    got101 = /HTTP\/1\.1 101/.test(buf.slice(0, i).toString());
    console.log('handshake status: "' + statusLine + '" ->', got101 ? 'OK (101 Switching Protocols)' : 'NOT 101');
    buf = buf.slice(i + 4);
    openAt = Date.now();
  }
  // Parse one unmasked server text frame: 0x81, len(<126), payload
  while (got101 && buf.length >= 2 && (buf[0] & 0x0f) === 1) {
    const len = buf[1] & 0x7f;
    if (buf.length < 2 + len) break;
    const payload = buf.slice(2, 2 + len).toString();
    buf = buf.slice(2 + len);
    if (payload === 'hello') { gotHello = true; console.log('received WebSocket frame after open: "' + payload + '"'); }
  }
});

s.on('close', () => {
  const sinceOpen = openAt ? Date.now() - openAt : -1;
  if (got101 && gotHello && sinceOpen >= 0 && sinceOpen < 1000) {
    finish(`\nBUG REPRODUCED: the WebSocket upgraded (101) and the open handler ran ` +
           `(we received "hello"), but the server closed the connection ${sinceOpen}ms ` +
           `later with no error and no close() call -- HttpResponse::cork() shut it down.`, 1);
  } else if (got101 && !gotHello) {
    finish('\nBUG REPRODUCED (variant): got the 101 handshake but the connection was ' +
           'closed before/without delivering the post-open frame.', 1);
  } else if (!got101) {
    finish('\nInconclusive: connection closed before the handshake completed.', 2);
  } else {
    finish('\nPASS: connection closed but only after staying open a while.', 0);
  }
});

s.on('error', (e) => finish('socket error: ' + e.message, 2));
// Healthy path: a correct server keeps the socket open indefinitely.
setTimeout(() => finish('\nPASS: WebSocket stayed open >1.5s after the handshake (no spurious close).', 0), 1500);
```
</details>
