### PR TITLE
Block all WebSocket sends after closeOnBackpressureLimit

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -115,24 +115,28 @@ public:
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = (WebSocketContextData<SSL, USERDATA> *) us_socket_context_ext(SSL,
             (us_socket_context_t *) us_socket_context(SSL, (us_socket_t *) this)
         );
+        WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
 
-        /* Skip sending and report success if we are over the limit of maxBackpressure */
+        /* Once closing due to backpressure, never send another frame */
+        if (webSocketData->isClosingDueToBackpressure) {
+            return DROPPED;
+        }
+
+        /* Skip sending if we are over the limit of maxBackpressure */
         if (webSocketContextData->maxBackpressure && webSocketContextData->maxBackpressure < getBufferedAmount()) {
             /* Also defer a close if we should */
             if (webSocketContextData->closeOnBackpressureLimit) {
+                webSocketData->isClosingDueToBackpressure = true;
                 us_socket_shutdown_read(SSL, (us_socket_t *) this);
             }
 
-            /* It is okay to call send again from within this callback since we immediately return with DROPPED afterwards */
+            /* Inform the application about the triggering dropped message */
             if (webSocketContextData->droppedHandler) {
                 webSocketContextData->droppedHandler(this, message, opCode);
             }
 
             return DROPPED;
         }
-
-        /* If we are subscribers and have messages to drain we need to drain them here to stay synced */
-        WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
 
         /* Special path for long sends of non-compressed, non-SSL messages */
         if (message.length() >= 16 * 1024 && !compress && !SSL && !webSocketData->subscriber && getBufferedAmount() == 0 && Super::getLoopData()->corkOffset == 0) {
@@ -156,6 +160,7 @@ public:
             }
         } else {
 
+            /* If we are subscribers and have messages to drain we need to drain them here to stay synced */
             if (webSocketData->subscriber) {
                 /* This will call back into us, send. */
                 webSocketContextData->topicTree->drain(webSocketData->subscriber);

--- a/src/WebSocketContext.h
+++ b/src/WebSocketContext.h
@@ -392,7 +392,7 @@ private:
             auto *webSocketData = (WebSocketData *)(us_socket_ext(SSL, s));
             auto *webSocketContextData = (WebSocketContextData<SSL, USERDATA> *) us_socket_context_ext(SSL, us_socket_context(SSL, (us_socket_t *) s));
 
-            if (webSocketContextData->sendPingsAutomatically && !webSocketData->isShuttingDown && !webSocketData->hasTimedOut) {
+            if (webSocketContextData->sendPingsAutomatically && !webSocketData->isShuttingDown && !webSocketData->isClosingDueToBackpressure && !webSocketData->hasTimedOut) {
                 webSocketData->hasTimedOut = true;
                 us_socket_timeout(SSL, s, webSocketContextData->idleTimeoutComponents.second);
                 /* Send ping without being corked */

--- a/src/WebSocketData.h
+++ b/src/WebSocketData.h
@@ -37,6 +37,7 @@ private:
     std::string fragmentBuffer;
     unsigned int controlTipLength = 0;
     bool isShuttingDown = 0;
+    bool isClosingDueToBackpressure = false;
     bool hasTimedOut = false;
     enum CompressionStatus : char {
         DISABLED,


### PR DESCRIPTION
Fixes #1338.

Once `closeOnBackpressureLimit` is triggered, store the closing state per WebSocket and return `DROPPED` for all subsequent sends, even if the backpressure drains below the limit.

The state is set before the dropped callback, making reentrant sends safe. Automatic timeout pings are also suppressed while closing.

The existing deferred shutdown behavior remains unchanged.

Tested by:
- Building all examples
- Running the complete ASan unit test suite
- Verifying drained, reentrant and subsequent sends remain dropped