### PR TITLE
Avoid crashes when publishing without WebSocket contexts

### DIFF
--- a/fuzzing/AsyncEpollHelloWorld.cpp
+++ b/fuzzing/AsyncEpollHelloWorld.cpp
@@ -36,6 +36,14 @@ void test() {
             listen_socket = listenSocket;
         });
 
+        /* Publishing without WebSocket contexts must be a no-op */
+        uWS::PreparedMessage preparedMessage = {};
+        if (app.publish("unused", "hi", uWS::TEXT) ||
+            app.publishPrepared("unused", preparedMessage) ||
+            app.numSubscribers("unused")) {
+            exit(-1);
+        }
+
         app.run();
     }
     uWS::Loop::get()->free();

--- a/src/App.h
+++ b/src/App.h
@@ -149,6 +149,10 @@ public:
 
     /* Same as publish, but takes a prepared message */
     bool publishPrepared(std::string_view topic, PreparedMessage &preparedMessage) {
+        if (!topicTree) {
+            return false;
+        }
+
         /* It is assumed by heuristics that a prepared message ought to be big,
          * and so there is no fast path for small messages (yet?) as preparing a small message is unlikely */
 
@@ -164,6 +168,10 @@ public:
      * TopicTree of this app (technically there are many TopicTrees, however the concept is that one
      * app has one conceptual Topic tree) */
     bool publish(std::string_view topic, std::string_view message, OpCode opCode, bool compress = false) {
+        if (!topicTree) {
+            return false;
+        }
+
         /* Anything big bypasses corking efforts */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
             return topicTree->publishBig(nullptr, topic, {message, opCode, compress}, [](Subscriber *s, TopicTreeBigMessage &message) {
@@ -181,6 +189,10 @@ public:
      * This function should probably be optimized a lot in future releases,
      * it could be O(1) with a hash map of fullnames and their counts. */
     unsigned int numSubscribers(std::string_view topic) {
+        if (!topicTree) {
+            return 0;
+        }
+
         Topic *t = topicTree->lookupTopic(topic);
         if (t) {
             return (unsigned int) t->size();


### PR DESCRIPTION
Fixes #1924.

Return `false` from `publish` and `publishPrepared`, and `0` from `numSubscribers`, when no `WebSocketContext` has been configured.

This avoids dereferencing a null `TopicTree` without allocating one or registering loop handlers for HTTP-only apps.

A regression check was added to the existing HTTP-only fuzz target.

Tested by:
- Building all examples
- Running the complete ASan unit test suite
- Running a targeted ASan/UBSan regression test