### PR TITLE
feat: add HttpRequest::hasBody()

### DIFF
--- a/src/HttpParser.h
+++ b/src/HttpParser.h
@@ -145,6 +145,11 @@ public:
         return std::string_view(headers->key.data(), headers->key.length());
     }
 
+    /* Returns whether the request declares a body that can be delivered through onData. */
+    bool hasBody() {
+        return getHeader("content-length").length() || getHeader("transfer-encoding").length();
+    }
+
     /* Returns the raw querystring as a whole, still encoded */
     std::string_view getQuery() {
         if (querySeparator < headers->value.length()) {

--- a/tests/HttpParser.cpp
+++ b/tests/HttpParser.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cassert>
+#include <string>
 
 #include "../src/HttpParser.h"
 
@@ -15,6 +16,8 @@ int main() {
     auto [err, returnedUser] = httpParser.consumePostPadded((char *) data, size, user, reserved, [reserved](void *s, uWS::HttpRequest *httpRequest) -> void * {
 
         std::cout << httpRequest->getMethod() << std::endl;
+
+        assert(!httpRequest->hasBody());
 
         for (auto [key, value] : *httpRequest) {
             std::cout << key << ": " << value << std::endl;
@@ -34,5 +37,22 @@ int main() {
     });
 
     std::cout << "HTTP DONE" << std::endl;
+
+    std::string bodyRequest = "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\ntest";
+    bodyRequest.append(8, '\0');
+    uWS::HttpParser bodyParser;
+    auto [bodyErr, bodyUser] = bodyParser.consumePostPadded(
+        bodyRequest.data(), (unsigned int) bodyRequest.length() - 8, user, reserved,
+        [](void *user, uWS::HttpRequest *httpRequest) -> void * {
+            assert(httpRequest->hasBody());
+            return user;
+        },
+        [](void *user, std::string_view data, bool) -> void * {
+            assert(data == "test");
+            return user;
+        }
+    );
+    assert(bodyErr == 0);
+    assert(bodyUser == user);
 
 }


### PR DESCRIPTION
Closes #1910.

Add `HttpRequest::hasBody()` so request handlers can determine whether the request declares a body before registering an `onData` handler.

The helper recognizes both `Content-Length` and `Transfer-Encoding`, matching the parser's body-selection logic. Tests cover requests with and without a declared body.

Validation:
- `make -C tests default`
- AddressSanitizer enabled by the test target
