### PR TITLE
Fix chunked write() and beginWrite() calls

### DIFF
--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -73,6 +73,32 @@ private:
         Super::write(buf, length);
     }
 
+    /* Switch to chunked encoding and terminate headers if we have not already.
+     * The header/body separator is written here, once. Chunks themselves always
+     * include their own trailing CRLF (RFC 9112). */
+    void ensureChunkedBodyStarted() {
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+
+        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+            writeMark();
+            writeHeader("Transfer-Encoding", "chunked");
+            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+
+            /* Start of the body */
+            Super::write("\r\n", 2);
+        }
+    }
+
+    /* Emit one complete chunk: chunk-size CRLF chunk-data CRLF.
+     * Super::write reports failed=true for backpressure even when all bytes
+     * were queued, so the trailer must still be written. */
+    bool writeChunk(std::string_view data) {
+        writeUnsignedHex((unsigned int) data.length());
+        Super::write("\r\n", 2);
+        Super::write(data.data(), (int) data.length());
+        return !Super::write("\r\n", 2).second;
+    }
+
     /* Called only once per request */
     void writeMark() {
         /* Date is always written */
@@ -121,16 +147,12 @@ private:
 
             /* Do not allow sending 0 chunk here */
             if (data.length()) {
-                Super::write("\r\n", 2);
-                writeUnsignedHex((unsigned int) data.length());
-                Super::write("\r\n", 2);
-
                 /* Ignoring optional for now */
-                Super::write(data.data(), (int) data.length());
+                writeChunk(data);
             }
 
             /* Terminating 0 chunk */
-            Super::write("\r\n0\r\n\r\n", 7);
+            Super::write("0\r\n\r\n", 5);
 
             httpResponseData->markDone();
 
@@ -432,18 +454,8 @@ public:
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-
-        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
-            /* Write mark on first call to write */
-            writeMark();
-
-            writeHeader("Transfer-Encoding", "chunked");
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
-
-            /* Start of the body */
-            Super::write("\r\n", 2);
-        }
+        /* Terminate headers now; later write()/end() emit complete chunks only */
+        ensureChunkedBodyStarted();
     }
 
     /* End without a body (no content-length) or end with a spoofed content-length. */
@@ -477,27 +489,15 @@ public:
             return true;
         }
 
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        ensureChunkedBodyStarted();
 
-        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
-            /* Write mark on first call to write */
-            writeMark();
-
-            writeHeader("Transfer-Encoding", "chunked");
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
-        }
-
-        Super::write("\r\n", 2);
-        writeUnsignedHex((unsigned int) data.length());
-        Super::write("\r\n", 2);
-
-        auto [written, failed] = Super::write(data.data(), (int) data.length());
-        if (failed) {
+        bool ok = writeChunk(data);
+        if (!ok) {
             Super::timeout(HTTP_TIMEOUT_S);
         }
 
         /* If we did not fail the write, accept more */
-        return !failed;
+        return ok;
     }
 
     /* Get the current byte write offset for this Http response */

--- a/tests/ChunkedEncoding.cpp
+++ b/tests/ChunkedEncoding.cpp
@@ -31,21 +31,7 @@ void consumeChunkEncoding(int maxConsume, std::string_view &chunkEncoded, uint64
         chunkEncoded.remove_prefix(data_length_before_parsing - data.length());
 
         if (state == 0) {
-
-            if (chunkEncoded.length() == 0 || chunkEncoded.length() == 74) {
-                break;
-            } else {
-                std::cerr << "consumeChunkEncoding failed" << std::endl;
-                std::cerr << "remaining chunk:" << chunkEncoded.length() << std::endl;
-                std::abort();
-            }
-
-            // should be fine
-            state = uWS::STATE_IS_CHUNKED;
-
-            //std::cout << "remaining chunk:" << chunkEncoded.length() << std::endl;
-            //std::abort();
-            //break;
+            break;
         }
 
         /* Here we must be in parsingchunked state */
@@ -68,15 +54,14 @@ void runBetterTest(unsigned int maxConsume) {
         ""
     };
 
-    /* Encode them in chunked encoding */
+    /* Encode them in chunked encoding.
+     * Last-chunk is 0 CRLF, then empty trailer-section CRLF (RFC 9112). */
     std::stringstream ss;
     for (std::string_view chunk : chunks) {
-        /* Generic chunked encoding format */
-        ss << std::hex << chunk.length() << "\r\n" << chunk << "\r\n";
-
-        /* Every null chunk is followed by an empty trailer */
         if (chunk.length() == 0) {
-            ss << "\r\n";
+            ss << "0\r\n\r\n";
+        } else {
+            ss << std::hex << chunk.length() << "\r\n" << chunk << "\r\n";
         }
     }
     std::string buffer = ss.str();
@@ -116,15 +101,14 @@ void runTest(unsigned int maxConsume) {
         ""
     };
 
-    /* Encode them in chunked encoding */
+    /* Encode them in chunked encoding.
+     * Last-chunk is 0 CRLF, then empty trailer-section CRLF (RFC 9112). */
     std::stringstream ss;
     for (std::string_view chunk : chunks) {
-        /* Generic chunked encoding format */
-        ss << std::hex << chunk.length() << "\r\n" << chunk << "\r\n";
-
-        /* Every null chunk is followed by an empty trailer */
         if (chunk.length() == 0) {
-            ss << "\r\n";
+            ss << "0\r\n\r\n";
+        } else {
+            ss << std::hex << chunk.length() << "\r\n" << chunk << "\r\n";
         }
     }
     std::string buffer = ss.str();

--- a/tests/HttpResponse.cpp
+++ b/tests/HttpResponse.cpp
@@ -1,0 +1,409 @@
+#include "../src/App.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <thread>
+
+/* Regression tests for chunked response framing (issue #1939).
+ * beginWrite() must terminate headers once; write()/end() must emit
+ * complete chunks (size CRLF data CRLF) without a leading extra CRLF. */
+
+static void dump(std::string_view s) {
+    for (unsigned char c : s) {
+        if (c == '\r') {
+            std::cerr << "\\r";
+        } else if (c == '\n') {
+            std::cerr << "\\n";
+        } else {
+            std::cerr << (char) c;
+        }
+    }
+}
+
+static std::string request(int port, const char *path) {
+    int fd = (int) ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        std::cerr << "socket failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t) port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    int connected = -1;
+    for (int i = 0; i < 50; i++) {
+        connected = ::connect(fd, (sockaddr *) &addr, sizeof(addr));
+        if (connected == 0) {
+            break;
+        }
+        ::close(fd);
+        fd = (int) ::socket(AF_INET, SOCK_STREAM, 0);
+        usleep(10000);
+    }
+
+    if (connected != 0) {
+        std::cerr << "connect failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    timeval tv{};
+    tv.tv_sec = 2;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    std::string req = std::string("GET ") + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    if (::send(fd, req.data(), req.size(), 0) != (ssize_t) req.size()) {
+        std::cerr << "send failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    std::string response;
+    char buf[2048];
+    while (true) {
+        ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n > 0) {
+            response.append(buf, (size_t) n);
+            continue;
+        }
+        if (n == 0) {
+            break;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        std::cerr << "recv failed: " << std::strerror(errno) << std::endl;
+        std::cerr << "partial response: ";
+        dump(response);
+        std::cerr << std::endl;
+        std::abort();
+    }
+
+    ::close(fd);
+    return response;
+}
+
+/* Send the request but do not read until the server has finished writing.
+ * Small SO_RCVBUF so the sender hits backpressure (write() returns false). */
+static std::string requestAfterBackpressure(int port, const char *path, std::atomic<bool> &written) {
+    int fd = (int) ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        std::cerr << "socket failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    int rcv = 4096;
+    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcv, sizeof(rcv));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t) port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    int connected = -1;
+    for (int i = 0; i < 50; i++) {
+        connected = ::connect(fd, (sockaddr *) &addr, sizeof(addr));
+        if (connected == 0) {
+            break;
+        }
+        ::close(fd);
+        fd = (int) ::socket(AF_INET, SOCK_STREAM, 0);
+        setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcv, sizeof(rcv));
+        usleep(10000);
+    }
+
+    if (connected != 0) {
+        std::cerr << "connect failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    std::string req = std::string("GET ") + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    if (::send(fd, req.data(), req.size(), 0) != (ssize_t) req.size()) {
+        std::cerr << "send failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    for (int i = 0; i < 500 && !written.load(); i++) {
+        usleep(10000);
+    }
+    if (!written.load()) {
+        std::cerr << "server did not finish backpressure writes" << std::endl;
+        std::abort();
+    }
+
+    timeval tv{};
+    tv.tv_sec = 10;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    std::string response;
+    char buf[8192];
+    while (true) {
+        ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n > 0) {
+            response.append(buf, (size_t) n);
+            continue;
+        }
+        if (n == 0) {
+            break;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        std::cerr << "recv failed: " << std::strerror(errno) << std::endl;
+        std::abort();
+    }
+
+    ::close(fd);
+    return response;
+}
+
+static std::string_view bodyOf(const std::string &response) {
+    size_t pos = response.find("\r\n\r\n");
+    if (pos == std::string::npos) {
+        std::cerr << "missing header terminator in: ";
+        dump(response);
+        std::cerr << std::endl;
+        std::abort();
+    }
+    return std::string_view(response).substr(pos + 4);
+}
+
+/* Walk RFC 9112 chunks. Fails if any chunk-data is missing its trailing CRLF. */
+static std::string decodeChunked(std::string_view body) {
+    std::string out;
+    size_t i = 0;
+
+    while (i < body.size()) {
+        size_t lineEnd = body.find("\r\n", i);
+        if (lineEnd == std::string_view::npos) {
+            std::cerr << "chunk-size line not terminated at offset " << i << "\nbody tail: ";
+            dump(body.substr(i, 32));
+            std::cerr << std::endl;
+            std::abort();
+        }
+
+        unsigned long size = 0;
+        for (size_t j = i; j < lineEnd; j++) {
+            char c = body[j];
+            size <<= 4;
+            if (c >= '0' && c <= '9') {
+                size += (unsigned long) (c - '0');
+            } else if (c >= 'a' && c <= 'f') {
+                size += (unsigned long) (c - 'a' + 10);
+            } else {
+                std::cerr << "invalid chunk-size hex at offset " << j << std::endl;
+                std::abort();
+            }
+        }
+
+        i = lineEnd + 2;
+        if (size == 0) {
+            if (body.substr(i) != "\r\n") {
+                std::cerr << "bad last-chunk trailer: ";
+                dump(body.substr(i));
+                std::cerr << std::endl;
+                std::abort();
+            }
+            return out;
+        }
+
+        if (i + size + 2 > body.size()) {
+            std::cerr << "truncated chunk of size " << size << " at offset " << i << std::endl;
+            std::abort();
+        }
+
+        if (body[i + size] != '\r' || body[i + size + 1] != '\n') {
+            std::cerr << "missing chunk-data CRLF after " << size
+                      << " byte chunk (backpressure write skipped the trailer)\nnext bytes: ";
+            dump(body.substr(i + size, 16));
+            std::cerr << std::endl;
+            std::abort();
+        }
+
+        out.append(body.data() + i, size);
+        i += size + 2;
+    }
+
+    std::cerr << "missing terminating 0 chunk" << std::endl;
+    std::abort();
+}
+
+static void expectChunked(int port, const char *path, std::string_view expectedBody) {
+    std::string response = request(port, path);
+
+    if (response.find("Transfer-Encoding: chunked\r\n") == std::string::npos) {
+        std::cerr << path << " missing Transfer-Encoding: chunked\n";
+        dump(response);
+        std::cerr << std::endl;
+        std::abort();
+    }
+
+    std::string_view body = bodyOf(response);
+    if (body != expectedBody) {
+        std::cerr << path << " unexpected chunked body\nexpected: ";
+        dump(expectedBody);
+        std::cerr << "\nactual:   ";
+        dump(body);
+        std::cerr << std::endl;
+        std::abort();
+    }
+
+    std::cout << "OK " << path << std::endl;
+}
+
+int main() {
+    uWS::App app;
+    uWS::Loop *loop = uWS::Loop::get();
+    int port = 0;
+    std::atomic<bool> backpressureWritten{false};
+    constexpr int chunkSize = 64 * 1024;
+    constexpr int maxFillChunks = 512;
+
+    app.get("/write-end", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->write("foo");
+            res->end();
+        });
+    }).get("/begin-write-end", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->write("foo");
+            res->end();
+        });
+    }).get("/begin-end", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->end();
+        });
+    }).get("/begin-end-data", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->end("foo");
+        });
+    }).get("/write-write-end", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->write("foo");
+            res->write("bar");
+            res->end();
+        });
+    }).get("/begin-write-write-end", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->write("foo");
+            res->write("bar");
+            res->end();
+        });
+    }).get("/write-end-data", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->write("foo");
+            res->end("bar");
+        });
+    }).get("/empty-write", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->write("");
+            res->end();
+        });
+    }).get("/hex-size", [](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            res->beginWrite();
+            res->write("hello world");
+            res->end();
+        });
+    }).get("/backpressure", [&](auto *res, auto * /*req*/) {
+        res->onAborted([]() {});
+        res->cork([res]() {
+            res->writeHeader("Content-Type", "text/plain");
+            std::string chunk((size_t) chunkSize, 'a');
+            int filled = 0;
+            while (res->write(chunk)) {
+                if (++filled >= maxFillChunks) {
+                    std::cerr << "did not hit backpressure after " << filled << " writes" << std::endl;
+                    std::abort();
+                }
+            }
+            /* This write is also backpressured: data is queued, write() returns false.
+             * The chunk trailer must still be present on the wire. */
+            res->write("foo");
+            res->end();
+        });
+        backpressureWritten.store(true);
+    }).listen(0, [&](us_listen_socket_t *listenSocket) {
+        if (!listenSocket) {
+            std::cerr << "Failed to listen" << std::endl;
+            std::exit(1);
+        }
+        port = us_socket_local_port(0, (us_socket_t *) listenSocket);
+    });
+
+    if (port <= 0) {
+        std::cerr << "listen returned no port" << std::endl;
+        return 1;
+    }
+
+    std::thread client([loop, &app, port, &backpressureWritten]() {
+        expectChunked(port, "/write-end", "3\r\nfoo\r\n0\r\n\r\n");
+        expectChunked(port, "/begin-write-end", "3\r\nfoo\r\n0\r\n\r\n");
+        expectChunked(port, "/begin-end", "0\r\n\r\n");
+        expectChunked(port, "/begin-end-data", "3\r\nfoo\r\n0\r\n\r\n");
+        expectChunked(port, "/write-write-end", "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n");
+        expectChunked(port, "/begin-write-write-end", "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n");
+        expectChunked(port, "/write-end-data", "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n");
+        expectChunked(port, "/empty-write", "0\r\n\r\n");
+        expectChunked(port, "/hex-size", "b\r\nhello world\r\n0\r\n\r\n");
+
+        std::string response = requestAfterBackpressure(port, "/backpressure", backpressureWritten);
+        if (response.find("Transfer-Encoding: chunked\r\n") == std::string::npos) {
+            std::cerr << "/backpressure missing Transfer-Encoding: chunked\n";
+            std::abort();
+        }
+        std::string decoded = decodeChunked(bodyOf(response));
+        if (decoded.size() < (size_t) chunkSize + 3 || decoded.compare(decoded.size() - 3, 3, "foo") != 0) {
+            std::cerr << "/backpressure decoded body should be N*'a' + \"foo\", got size "
+                      << decoded.size() << std::endl;
+            std::abort();
+        }
+        for (size_t i = 0; i + 3 < decoded.size(); i++) {
+            if (decoded[i] != 'a') {
+                std::cerr << "/backpressure unexpected byte at " << i << std::endl;
+                std::abort();
+            }
+        }
+        std::cout << "OK /backpressure (" << decoded.size() << " decoded bytes)" << std::endl;
+
+        loop->defer([&app]() {
+            app.close();
+        });
+    });
+
+    app.run();
+    client.join();
+    return 0;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,9 @@ default:
 	./ExtensionsNegotiator
 	$(CXX) -std=c++17 -fsanitize=address HttpParser.cpp -o HttpParser
 	./HttpParser
+	$(MAKE) -C ../uSockets
+	$(CXX) -std=c++17 -fsanitize=address -flto=auto -I../src -I../uSockets/src HttpResponse.cpp ../uSockets/*.o -lz -pthread -o HttpResponse
+	./HttpResponse
 
 performance:
 	$(CXX) -std=c++17 HttpRouter.cpp -O3 -o HttpRouter


### PR DESCRIPTION
## Summary

Fixes [uNetworking/uWebSockets#1939](https://github.com/uNetworking/uWebSockets/issues/1939): HTTP/1.1 chunked `write()` / `beginWrite()` / `end()` did not emit complete chunks as defined by [RFC 9112 §7.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1).

`write()` prefixed a `CRLF` and omitted the chunk-data trailer. That leading `CRLF` was reused as (1) the header/body separator on the first call and (2) the previous chunk’s trailer on later calls. `beginWrite()` already wrote the header terminator, so the first `write()` added a second `CRLF`. A spec-compliant parser then treated `0x0D` as a chunk-size digit (`chunk hex-length char not a hex digit: 0xd`).

On a long-lived stream that never calls `end()` (SSE), the last `write()` had no following operation to supply the deferred trailer, so the last event was not a complete chunk and was not delivered.

This PR makes each `write()` emit a complete `chunk`, makes `beginWrite()` only terminate headers, and makes `end()` emit only `last-chunk` + empty `trailer-section` + final `CRLF`.

## Spec (why the old bytes were illegal)

[RFC 9112 §2.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-2.1) — headers end with one empty line:

```
HTTP-message = start-line CRLF
               *( field-line CRLF )
               CRLF
               [ message-body ]
```

[RFC 9112 §7.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1) — the body, when `Transfer-Encoding: chunked`, is:

```
chunked-body   = *chunk
                 last-chunk
                 trailer-section
                 CRLF

chunk          = chunk-size [ chunk-ext ] CRLF
                 chunk-data CRLF
last-chunk     = 1*("0") [ chunk-ext ] CRLF
trailer-section = *( field-line CRLF )
```

A data chunk is therefore `HEXDIG+ CRLF chunk-data CRLF`. The chunk-data `CRLF` is part of **this** chunk, not a prefix of the next write.

`last-chunk` with an empty trailer is exactly `0 CRLF` + *(no field-lines)* + `CRLF` → `0\r\n\r\n`.

Older grammar, same bytes: [RFC 7230 §4.1](https://www.rfc-editor.org/rfc/rfc7230.html#section-4.1) (`chunk-data CRLF`, `last-chunk`, `trailer-part CRLF`).

## What was on the wire

**Before (deferred trailer / “CRLF before”):**

```
write("foo")  →  CRLF  3  CRLF  foo
write("bar")  →  CRLF  3  CRLF  bar
end()         →  CRLF  0  CRLF  CRLF
```

A finished `write(); write(); end()` happened to look legal because the next call’s leading `CRLF` closed the previous chunk. The **current** chunk was never closed until the next `write()` or `end()`.

**`beginWrite(); write("foo"); end()`** (issue 1939):

```
headers CRLF          ← beginWrite() (correct header terminator)
CRLF  3  CRLF  foo    ← write() still prefixes CRLF
CRLF  0  CRLF  CRLF
```

That extra `CRLF` is a chunk-size line whose first byte is `CR` (0x0D). Curl is correct to reject it.

**Never-ending / SSE:** `beginWrite(); write(event N);` and wait. Event N is `size CRLF data` with no chunk-data `CRLF`. A compliant HTTP/1.1 decoder must not deliver those bytes until the trailer arrives ([RFC 9112 §7.1.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.1): `chunk-data` length is `chunk-size`, then `CRLF`). The SSE parser never sees a finished frame.

**After:**

```
beginWrite()     →  headers CRLF          // §2.1 empty line, once
write("foo")     →  3 CRLF foo CRLF       // complete chunk
write("bar")     →  3 CRLF bar CRLF
end()            →  0 CRLF CRLF           // last-chunk + empty trailer
```

`write(); end()` without `beginWrite()` is byte-identical to the old successful path. `beginWrite(); write(); end()` now matches that path (13 bytes of body for `"foo"`, not 15).

## Additional Context

### Why the trailer is unconditional (backpressure)

`AsyncSocket::write`’s `failed` flag means **backpressure**, not “bytes were dropped”. Non-optional writes always accept the buffer: leftover bytes are appended and the call returns `{length, true}` (`src/AsyncSocket.h`, already-buffered path and short `us_socket_write`).

If `writeChunk()` skipped the trailer when `failed` was true, a 64 KiB `write()` that filled the socket would queue `10000 CRLF <data>` with no `CRLF`, then the next `write("foo")` / `end()` would start a new chunk. A decoder reading size `0x10000` would then see `3` instead of `CRLF`.

The trailer `Super::write("\r\n", 2)` in that state also appends to the same per-socket buffer. `write()` still returns `false` so callers back off.

### What about `tests/ChunkedEncoding.cpp`?

This file does **not** change `src/ChunkedEncoding.h`. It only fixes the **encoder** used by the existing parser brute-force test.

The fixture listed two concatenated chunked bodies, with `""` meaning last-chunk. It encoded each empty element as:

```
hex(0) CRLF  +  data("")  +  CRLF  +  extra CRLF
= 0\r\n\r\n\r\n
```

That is last-chunk `0\r\n` + empty trailer `CRLF` + a **surplus** `CRLF`.

[RFC 9112 §7.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1) last-chunk + empty `trailer-section` + final `CRLF` is `0\r\n\r\n`. The parser (already, on master) finishes the first `chunked-body` there and correctly leaves the surplus `CRLF`.

Byte count on the old fixture (why CI printed `remaining chunk:76`):

| Piece | Bytes |
|---|---|
| `22 CRLF` + 34 + `CRLF` | 40 |
| `f CRLF` + 15 + `CRLF` | 20 |
| `0\r\n\r\n\r\n` | 7 |
| **first body** | **67** |
| second body (same shape) | 74 |
| **total** | **141** |

Parser consumes last-chunk + trailer = 5 bytes of the `0\r\n\r\n\r\n`, not 7. Consumed = 40 + 20 + 5 = 65. Remaining = 141 − 65 = **76** = surplus `CRLF` + 74-byte second body.

The test then required leftover `== 0 || == 74`. That 74 assumed the parser would swallow the illegal extra `CRLF`. It must not: that `CRLF` is not part of the first `chunked-body`. After the first body, leftover 76 is the spec-correct remainder for the old fixture.

This PR encodes empty elements as `0\r\n\r\n` only. First body becomes 65 bytes, second 72, leftover after the first parse is exactly the second body. `consumeChunkEncoding` now stops on `state == 0` (one `chunked-body` finished) instead of a magic leftover length that encoded the surplus `CRLF`.

`testWithoutTrailer()` already emitted `0\r\n\r\n` via the generic `size CRLF data CRLF` path for empty data; it is unchanged.
